### PR TITLE
Freeze v0.1 operation accountability package and handoff docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+你在当前仓库中的首要任务，是复用现有资产，补齐一个“最小可验证闭环”。
+
+## 仓库级目标
+围绕以下五部分推进：
+- operation
+- policy
+- provenance
+- evidence
+- validation
+
+本轮只交付四类东西：
+1. minimal profile
+2. profile-aware validator
+3. 单链路 demo
+4. 对外文稿骨架
+
+## 目录策略
+先复用现有目录，不要平行新建第二套体系。
+
+优先级：
+- 已有 `spec/` 就扩 `spec/`
+- 已有 `schema/` 就补 `schema/`
+- 已有 `examples/` 就补 `examples/`
+- 已有 `verify/` 或现有 CLI / scripts / tests，就沿用
+- 已有 `demo/` 就在原 demo 位置补闭环
+- 已有 `submission/` 或文稿目录，就优先放文稿骨架
+
+只有确实缺失时才新增目录。
+
+## 禁止事项
+- 不要扩展成泛化 agent governance 平台
+- 不要新造大而全 registry
+- 不要试图一次解决全量跨风味 FDO 映射
+- 不要追求完整密码学基础设施
+- 不要做复杂多智能体编排
+- 不要用宏大叙事替代可运行产物
+
+## 产出标准
+必须形成：
+- 1 个 valid 样例
+- 3 个 invalid 样例，且每个 invalid 只故意打破 1 条主规则
+- validator 至少检查：
+  - 结构完整性
+  - 必填字段
+  - 引用闭合
+  - policy / provenance / evidence 关联一致性
+- validator 输出：
+  - 机器可读 JSON
+  - 人可读失败摘要
+  - 明确 error code
+- demo 必须闭环：
+  对象载入或创建
+  → profile 检查
+  → operation 调用
+  → evidence 生成
+  → validator 验证
+  → 输出验证结果
+
+## 执行方式
+- 先扫描仓库
+- 先写 `docs/STATUS.md`
+- 再写 `plans/implementation-plan.md`
+- 然后按最小增量补齐 profile / examples / validator / demo / 文稿骨架
+- 每完成一个 milestone，更新 `docs/STATUS.md`
+- 优先最小、最稳、最容易测试的方案

--- a/README.md
+++ b/README.md
@@ -122,6 +122,57 @@ pip install -e ".[dev,langchain,sql]"
 agent-evidence schema
 ```
 
+## Current v0.1 package
+
+The current minimal handoff package is
+`Execution Evidence and Operation Accountability Profile v0.1`.
+
+Start here for the current v0.1 path:
+
+- Spec: `spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- Schema: `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- Validator CLI: `agent-evidence validate-profile <file>`
+- Examples: `examples/README.md`
+- Demo: `demo/README.md`
+- Status and acceptance: `docs/STATUS.md`, `docs/ACCEPTANCE-CHECKLIST.md`
+- Submission handoff: `submission/package-manifest.md`, `submission/final-handoff.md`
+
+Historical `Execution Evidence Object` and `Agent Evidence Profile` surfaces
+remain in this repository, but they are not the primary v0.1 package path.
+
+## Minimal v0.1 walkthrough
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Validate the minimal valid and invalid examples:
+
+```bash
+agent-evidence validate-profile examples/minimal-valid-evidence.json
+agent-evidence validate-profile examples/invalid-missing-required.json
+agent-evidence validate-profile examples/invalid-unclosed-reference.json
+agent-evidence validate-profile examples/invalid-policy-link-broken.json
+```
+
+Run the minimal demo:
+
+```bash
+python3 demo/run_operation_accountability_demo.py
+```
+
+Expected result:
+
+- the valid example returns JSON with `"ok": true`
+- each invalid example returns JSON with `"ok": false` and one primary error code
+- the demo writes artifacts under `demo/artifacts/` and ends with one `PASS` summary line
+
+Known environment note:
+
+- the repository `.venv` may show one `langchain_core` warning under Python 3.14 during broader test runs; it does not affect the minimal profile, validator, or demo path
+
 ## Agent Evidence Profile v0.1 MVP
 
 The current MVP path is an integrity-verifiable evidence bundle with offline

--- a/agent_evidence/__init__.py
+++ b/agent_evidence/__init__.py
@@ -20,6 +20,7 @@ from .manifest import (
     VerificationKey,
 )
 from .models import EvidenceContext, EvidenceEnvelope, EvidenceEvent, EvidenceHashes
+from .oap import validate_profile_file, with_recomputed_integrity
 from .recorder import EvidenceRecorder
 from .storage import LocalEvidenceStore, open_store
 
@@ -42,11 +43,13 @@ __all__ = [
     "export_xml_bundle",
     "open_store",
     "package_export_archive",
+    "validate_profile_file",
     "verify_bundle",
     "verify_csv_export",
     "verify_export_archive",
     "verify_json_bundle",
     "verify_xml_export",
+    "with_recomputed_integrity",
 ]
 
 try:

--- a/agent_evidence/cli/main.py
+++ b/agent_evidence/cli/main.py
@@ -25,6 +25,7 @@ from agent_evidence.export import (
 from agent_evidence.integrations import export_automaton_bundle
 from agent_evidence.manifest import SignaturePolicy, SignerConfig, VerificationKey
 from agent_evidence.models import EvidenceEnvelope
+from agent_evidence.oap import validate_profile_file
 from agent_evidence.recorder import EvidenceRecorder
 from agent_evidence.storage import migrate_records, open_store
 from agent_evidence.storage.base import EvidenceStore
@@ -370,6 +371,25 @@ def verify(store_target: str) -> None:
     click.echo(json.dumps(result, indent=2, sort_keys=True))
     if issues:
         raise click.ClickException("Evidence chain verification failed.")
+
+
+@main.command(name="validate-profile")
+@click.argument("profile_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--schema",
+    "schema_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+def validate_profile_command(profile_path: Path, schema_path: Path | None) -> None:
+    """Validate the operation accountability profile JSON file."""
+
+    try:
+        report = validate_profile_file(profile_path, schema_path=schema_path)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(json.dumps(report, indent=2, sort_keys=True))
+    if not report["ok"]:
+        raise SystemExit(1)
 
 
 @main.command()

--- a/agent_evidence/oap.py
+++ b/agent_evidence/oap.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+PROFILE_NAME = "execution-evidence-operation-accountability-profile"
+PROFILE_VERSION = "0.1"
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schema" / f"{PROFILE_NAME}-v{PROFILE_VERSION}.schema.json"
+
+
+def load_profile(path: str | Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON profile: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("profile payload must be a JSON object")
+    return payload
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def sha256_digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def statement_core(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "actor": profile["actor"],
+        "subject": profile["subject"],
+        "operation": profile["operation"],
+        "policy": profile["policy"],
+        "constraints": profile["constraints"],
+        "provenance": profile["provenance"],
+    }
+
+
+def recompute_integrity(profile: dict[str, Any]) -> dict[str, str]:
+    evidence = profile["evidence"]
+    return {
+        "references_digest": sha256_digest(evidence["references"]),
+        "artifacts_digest": sha256_digest(evidence["artifacts"]),
+        "statement_digest": sha256_digest(statement_core(profile)),
+    }
+
+
+def with_recomputed_integrity(profile: dict[str, Any]) -> dict[str, Any]:
+    updated = copy.deepcopy(profile)
+    updated["evidence"]["integrity"] = recompute_integrity(updated)
+    return updated
+
+
+def _issue(stage: str, code: str, path: str, message: str) -> dict[str, str]:
+    return {
+        "stage": stage,
+        "code": code,
+        "path": path,
+        "message": message,
+    }
+
+
+def _validate_schema(
+    profile: dict[str, Any], schema_path: str | Path = SCHEMA_PATH
+) -> list[dict[str, str]]:
+    schema = json.loads(Path(schema_path).read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    issues: list[dict[str, str]] = []
+    for error in sorted(validator.iter_errors(profile), key=lambda item: list(item.path)):
+        path = ".".join(str(part) for part in error.path) or "root"
+        issues.append(_issue("schema", "schema_violation", path, error.message))
+    return issues
+
+
+def _duplicate_ids(values: list[str], stage: str, code: str, path: str) -> list[dict[str, str]]:
+    seen: set[str] = set()
+    issues: list[dict[str, str]] = []
+    for value in values:
+        if value in seen:
+            issues.append(_issue(stage, code, path, f"duplicate identifier found: {value}"))
+        seen.add(value)
+    return issues
+
+
+def _validate_reference_closure(profile: dict[str, Any]) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+    actor_id = profile["actor"]["id"]
+    subject_id = profile["subject"]["id"]
+    operation_id = profile["operation"]["id"]
+    policy_id = profile["policy"]["id"]
+    provenance_id = profile["provenance"]["id"]
+    evidence_id = profile["evidence"]["id"]
+
+    constraint_ids = [constraint["id"] for constraint in profile["constraints"]]
+    reference_ids = [reference["ref_id"] for reference in profile["evidence"]["references"]]
+
+    issues.extend(
+        _duplicate_ids(
+            constraint_ids,
+            "references",
+            "duplicate_constraint_id",
+            "constraints",
+        )
+    )
+    issues.extend(
+        _duplicate_ids(
+            reference_ids,
+            "references",
+            "duplicate_reference_id",
+            "evidence.references",
+        )
+    )
+
+    constraint_id_set = set(constraint_ids)
+    reference_id_set = set(reference_ids)
+
+    if profile["operation"]["subject_ref"] != subject_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_subject_ref",
+                "operation.subject_ref",
+                "operation.subject_ref must resolve to subject.id.",
+            )
+        )
+    if profile["operation"]["policy_ref"] != policy_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_policy_ref",
+                "operation.policy_ref",
+                "operation.policy_ref must resolve to policy.id.",
+            )
+        )
+    for index, value in enumerate(profile["policy"]["constraint_refs"]):
+        if value not in constraint_id_set:
+            issues.append(
+                _issue(
+                    "references",
+                    "unresolved_constraint_ref",
+                    f"policy.constraint_refs[{index}]",
+                    "policy constraint ref does not resolve to constraints[].id.",
+                )
+            )
+
+    for index, value in enumerate(profile["operation"]["input_refs"]):
+        if value not in reference_id_set:
+            issues.append(
+                _issue(
+                    "references",
+                    "unresolved_input_ref",
+                    f"operation.input_refs[{index}]",
+                    "operation input ref does not resolve to evidence.references[].ref_id.",
+                )
+            )
+    for index, value in enumerate(profile["operation"]["output_refs"]):
+        if value not in reference_id_set:
+            issues.append(
+                _issue(
+                    "references",
+                    "unresolved_output_ref",
+                    f"operation.output_refs[{index}]",
+                    "operation output ref does not resolve to evidence.references[].ref_id.",
+                )
+            )
+
+    if profile["provenance"]["actor_ref"] != actor_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_actor_ref",
+                "provenance.actor_ref",
+                "provenance.actor_ref must resolve to actor.id.",
+            )
+        )
+    if profile["provenance"]["operation_ref"] != operation_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_operation_ref",
+                "provenance.operation_ref",
+                "provenance.operation_ref must resolve to operation.id.",
+            )
+        )
+    if profile["provenance"]["subject_ref"] != subject_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_provenance_subject_ref",
+                "provenance.subject_ref",
+                "provenance.subject_ref must resolve to subject.id.",
+            )
+        )
+    if profile["evidence"]["subject_ref"] != subject_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_evidence_subject_ref",
+                "evidence.subject_ref",
+                "evidence.subject_ref must resolve to subject.id.",
+            )
+        )
+    if profile["evidence"]["operation_ref"] != operation_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_evidence_operation_ref",
+                "evidence.operation_ref",
+                "evidence.operation_ref must resolve to operation.id.",
+            )
+        )
+    if profile["evidence"]["policy_ref"] != policy_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_evidence_policy_ref",
+                "evidence.policy_ref",
+                "evidence.policy_ref must resolve to policy.id.",
+            )
+        )
+
+    if profile["validation"]["evidence_ref"] != evidence_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_validation_evidence_ref",
+                "validation.evidence_ref",
+                "validation.evidence_ref must resolve to evidence.id.",
+            )
+        )
+    if profile["validation"]["provenance_ref"] != provenance_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_validation_provenance_ref",
+                "validation.provenance_ref",
+                "validation.provenance_ref must resolve to provenance.id.",
+            )
+        )
+    if profile["validation"]["policy_ref"] != policy_id:
+        issues.append(
+            _issue(
+                "references",
+                "unresolved_validation_policy_ref",
+                "validation.policy_ref",
+                "validation.policy_ref must resolve to policy.id.",
+            )
+        )
+    return issues
+
+
+def _validate_link_consistency(profile: dict[str, Any]) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+    reference_roles = {
+        reference["ref_id"]: reference["role"] for reference in profile["evidence"]["references"]
+    }
+    reference_object_ids = {
+        reference["ref_id"]: reference["object_id"]
+        for reference in profile["evidence"]["references"]
+    }
+    subject_id = profile["subject"]["id"]
+
+    for index, value in enumerate(profile["operation"]["input_refs"]):
+        if reference_roles.get(value) not in (None, "input"):
+            issues.append(
+                _issue(
+                    "consistency",
+                    "input_ref_role_mismatch",
+                    f"operation.input_refs[{index}]",
+                    "operation input refs must point to evidence references with role input.",
+                )
+            )
+    for index, value in enumerate(profile["operation"]["output_refs"]):
+        if reference_roles.get(value) not in (None, "output"):
+            issues.append(
+                _issue(
+                    "consistency",
+                    "output_ref_role_mismatch",
+                    f"operation.output_refs[{index}]",
+                    "operation output refs must point to evidence references with role output.",
+                )
+            )
+
+    if profile["provenance"]["input_refs"] != profile["operation"]["input_refs"]:
+        issues.append(
+            _issue(
+                "consistency",
+                "provenance_input_refs_mismatch",
+                "provenance.input_refs",
+                "provenance.input_refs must match operation.input_refs.",
+            )
+        )
+    if profile["provenance"]["output_refs"] != profile["operation"]["output_refs"]:
+        issues.append(
+            _issue(
+                "consistency",
+                "provenance_output_refs_mismatch",
+                "provenance.output_refs",
+                "provenance.output_refs must match operation.output_refs.",
+            )
+        )
+
+    policy_refs = {
+        "operation.policy_ref": profile["operation"]["policy_ref"],
+        "evidence.policy_ref": profile["evidence"]["policy_ref"],
+        "validation.policy_ref": profile["validation"]["policy_ref"],
+    }
+    if len(set(policy_refs.values())) != 1:
+        issues.append(
+            _issue(
+                "consistency",
+                "policy_ref_mismatch",
+                ",".join(policy_refs.keys()),
+                "operation, evidence, and validation must carry the same policy ref.",
+            )
+        )
+
+    if profile["evidence"]["operation_ref"] != profile["provenance"]["operation_ref"]:
+        issues.append(
+            _issue(
+                "consistency",
+                "operation_ref_mismatch",
+                "evidence.operation_ref",
+                "evidence.operation_ref must match provenance.operation_ref.",
+            )
+        )
+    if profile["evidence"]["subject_ref"] != profile["provenance"]["subject_ref"]:
+        issues.append(
+            _issue(
+                "consistency",
+                "subject_ref_mismatch",
+                "evidence.subject_ref",
+                "evidence.subject_ref must match provenance.subject_ref.",
+            )
+        )
+
+    input_refs = profile["operation"]["input_refs"]
+    if not any(reference_object_ids.get(ref_id) == subject_id for ref_id in input_refs):
+        issues.append(
+            _issue(
+                "consistency",
+                "subject_input_reference_missing",
+                "operation.input_refs",
+                "at least one input ref must point to the subject object.",
+            )
+        )
+    return issues
+
+
+def _validate_integrity(profile: dict[str, Any]) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+    expected = recompute_integrity(profile)
+    actual = profile["evidence"]["integrity"]
+
+    for field in ("references_digest", "artifacts_digest", "statement_digest"):
+        if actual.get(field) != expected[field]:
+            issues.append(
+                _issue(
+                    "integrity",
+                    f"{field}_mismatch",
+                    f"evidence.integrity.{field}",
+                    f"{field} does not match the canonical recomputed digest.",
+                )
+            )
+    return issues
+
+
+def build_validation_report(
+    profile: dict[str, Any],
+    *,
+    schema_path: str | Path | None = None,
+    source: str | None = None,
+) -> dict[str, Any]:
+    resolved_schema_path = schema_path or SCHEMA_PATH
+    schema_issues = _validate_schema(profile, resolved_schema_path)
+    reference_issues: list[dict[str, str]] = []
+    consistency_issues: list[dict[str, str]] = []
+    integrity_issues: list[dict[str, str]] = []
+
+    if not schema_issues:
+        reference_issues = _validate_reference_closure(profile)
+    if not schema_issues and not reference_issues:
+        consistency_issues = _validate_link_consistency(profile)
+    if not schema_issues and not reference_issues and not consistency_issues:
+        integrity_issues = _validate_integrity(profile)
+
+    stages = [
+        {"name": "schema", "ok": not schema_issues, "issues": schema_issues},
+        {"name": "references", "ok": not reference_issues, "issues": reference_issues},
+        {"name": "consistency", "ok": not consistency_issues, "issues": consistency_issues},
+        {"name": "integrity", "ok": not integrity_issues, "issues": integrity_issues},
+    ]
+    issues = [issue for stage in stages for issue in stage["issues"]]
+    report = {
+        "ok": not issues,
+        "profile": f"{PROFILE_NAME}@{PROFILE_VERSION}",
+        "source": source,
+        "issue_count": len(issues),
+        "stages": stages,
+        "summary": render_summary_lines(
+            {
+                "ok": not issues,
+                "profile": f"{PROFILE_NAME}@{PROFILE_VERSION}",
+                "source": source,
+                "issue_count": len(issues),
+                "issues": issues,
+            }
+        ),
+    }
+    return report
+
+
+def validate_profile_file(
+    path: str | Path,
+    *,
+    schema_path: str | Path | None = None,
+) -> dict[str, Any]:
+    profile = load_profile(path)
+    return build_validation_report(profile, schema_path=schema_path, source=str(path))
+
+
+def render_summary_lines(report: dict[str, Any]) -> list[str]:
+    source = report.get("source") or "<memory>"
+    profile = report["profile"]
+    if report["ok"]:
+        return [f"PASS {profile} {source}"]
+
+    lines = [f"FAIL {profile} {source} ({report['issue_count']} issue(s))"]
+    for issue in report["issues"]:
+        lines.append(f"[{issue['code']}] {issue['path']}: {issue['message']}")
+    return lines

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,20 @@
+# Minimal Demo
+
+This demo implements one policy-constrained metadata enrichment path.
+
+Flow:
+
+1. load one source object
+2. run a minimal profile precheck
+3. apply one constrained operation
+4. generate one operation accountability statement
+5. validate the statement with the profile-aware validator
+6. write artifacts and one validation report for review
+
+Run:
+
+```bash
+python3 demo/run_operation_accountability_demo.py
+```
+
+Artifacts are written under `demo/artifacts/`.

--- a/demo/expected-output.md
+++ b/demo/expected-output.md
@@ -1,0 +1,88 @@
+# Expected Output
+
+## Valid Example
+
+Command:
+
+```bash
+agent-evidence validate-profile examples/minimal-valid-evidence.json
+```
+
+Expected summary:
+
+- JSON output includes `"ok": true`
+- `issue_count` is `0`
+- `summary` contains one `PASS execution-evidence-operation-accountability-profile@0.1 ...` line
+
+## Invalid Examples
+
+### Missing required field
+
+Command:
+
+```bash
+agent-evidence validate-profile examples/invalid-missing-required.json
+```
+
+Expected summary:
+
+- JSON output includes `"ok": false`
+- primary error code: `schema_violation`
+- failure reason: `validation.method` is missing
+
+### Unclosed reference
+
+Command:
+
+```bash
+agent-evidence validate-profile examples/invalid-unclosed-reference.json
+```
+
+Expected summary:
+
+- JSON output includes `"ok": false`
+- primary error code: `unresolved_output_ref`
+- failure reason: `operation.output_refs[0]` points to `ref:missing-output`
+
+### Broken policy link
+
+Command:
+
+```bash
+agent-evidence validate-profile examples/invalid-policy-link-broken.json
+```
+
+Expected summary:
+
+- JSON output includes `"ok": false`
+- primary error code: `unresolved_evidence_policy_ref`
+- failure reason: `evidence.policy_ref` does not resolve to `policy.id`
+
+## Demo Script
+
+Command:
+
+```bash
+python3 demo/run_operation_accountability_demo.py
+```
+
+Main output shape:
+
+1. `Step 1: object load or creation`
+2. `Step 2: profile precheck`
+3. `Step 3: operation call`
+4. `Step 4: evidence generation`
+5. `Step 5: validator verification`
+6. `Step 6: output verification result`
+
+Expected end state:
+
+- one `PASS execution-evidence-operation-accountability-profile@0.1 ...` line
+- `demo/artifacts/minimal-profile-evidence.json` exists
+- `demo/artifacts/validation-report.json` exists
+
+## Error Code Reference
+
+- `schema_violation`: required field or field shape does not satisfy the schema
+- `unresolved_output_ref`: an operation output ref does not resolve to `evidence.references[].ref_id`
+- `unresolved_evidence_policy_ref`: `evidence.policy_ref` does not resolve to `policy.id`

--- a/demo/run_operation_accountability_demo.py
+++ b/demo/run_operation_accountability_demo.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+DEMO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = DEMO_ROOT.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agent_evidence.oap import (  # noqa: E402
+    render_summary_lines,
+    sha256_digest,
+    validate_profile_file,
+    with_recomputed_integrity,
+)
+
+ARTIFACTS_DIR = DEMO_ROOT / "artifacts"
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_source_object() -> dict[str, object]:
+    return {
+        "object_id": "obj:client-note-001",
+        "type": "client-note",
+        "content": "Client asked for the next delivery estimate and follow-up report.",
+        "metadata": {
+            "source": "visit-note",
+            "owner": "sales-ops",
+        },
+    }
+
+
+def profile_precheck(source_object: dict[str, object]) -> list[str]:
+    issues: list[str] = []
+    for field in ("object_id", "type", "content", "metadata"):
+        if field not in source_object:
+            issues.append(f"missing source field: {field}")
+    metadata = source_object.get("metadata")
+    if not isinstance(metadata, dict):
+        issues.append("source metadata must be an object")
+    return issues
+
+
+def apply_operation(
+    source_object: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object]]:
+    derived_object = copy.deepcopy(source_object)
+    derived_object["object_id"] = "obj:client-note-001-derived"
+    metadata = dict(derived_object["metadata"])
+    metadata["review_status"] = "approved"
+    metadata["tags"] = ["client-visit", "delivery-follow-up"]
+    derived_object["metadata"] = metadata
+
+    operation_log = {
+        "operation": "metadata.enrich",
+        "policy": "approved-metadata-policy",
+        "added_fields": ["review_status", "tags"],
+        "content_changed": False,
+    }
+    return derived_object, operation_log
+
+
+def build_statement(
+    source_object: dict[str, object],
+    derived_object: dict[str, object],
+    operation_log: dict[str, object],
+) -> dict[str, object]:
+    statement = {
+        "profile": {
+            "name": "execution-evidence-operation-accountability-profile",
+            "version": "0.1",
+        },
+        "statement_id": "eeoap:demo-metadata-enrichment-001",
+        "timestamp": "2026-03-30T00:00:00Z",
+        "actor": {
+            "id": "actor:metadata-enricher",
+            "type": "agent",
+            "name": "metadata-enricher",
+            "runtime": "openai-agents",
+        },
+        "subject": {
+            "id": source_object["object_id"],
+            "type": "fdo-record",
+            "digest": sha256_digest(source_object),
+            "locator": "demo/artifacts/input-object.json",
+        },
+        "operation": {
+            "id": "op:metadata-enrich-001",
+            "type": "metadata.enrich",
+            "description": "Add approved metadata tags to one client note object.",
+            "subject_ref": source_object["object_id"],
+            "policy_ref": "policy:approved-metadata-v1",
+            "input_refs": ["ref:input-note"],
+            "output_refs": ["ref:output-note"],
+            "result": {
+                "status": "succeeded",
+                "summary": "one derived note object emitted",
+            },
+        },
+        "policy": {
+            "id": "policy:approved-metadata-v1",
+            "name": "approved-metadata-policy",
+            "constraint_refs": [
+                "constraint:approved-fields",
+                "constraint:no-content-rewrite",
+            ],
+        },
+        "constraints": [
+            {
+                "id": "constraint:approved-fields",
+                "description": "Only approved metadata fields may be added.",
+            },
+            {
+                "id": "constraint:no-content-rewrite",
+                "description": "The note body must remain unchanged.",
+            },
+        ],
+        "provenance": {
+            "id": "prov:metadata-enrich-001",
+            "actor_ref": "actor:metadata-enricher",
+            "operation_ref": "op:metadata-enrich-001",
+            "subject_ref": source_object["object_id"],
+            "input_refs": ["ref:input-note"],
+            "output_refs": ["ref:output-note"],
+        },
+        "evidence": {
+            "id": "evidence:metadata-enrich-001",
+            "subject_ref": source_object["object_id"],
+            "operation_ref": "op:metadata-enrich-001",
+            "policy_ref": "policy:approved-metadata-v1",
+            "references": [
+                {
+                    "ref_id": "ref:input-note",
+                    "role": "input",
+                    "object_id": source_object["object_id"],
+                    "digest": sha256_digest(source_object),
+                    "locator": "demo/artifacts/input-object.json",
+                },
+                {
+                    "ref_id": "ref:output-note",
+                    "role": "output",
+                    "object_id": derived_object["object_id"],
+                    "digest": sha256_digest(derived_object),
+                    "locator": "demo/artifacts/derived-object.json",
+                },
+            ],
+            "artifacts": [
+                {
+                    "artifact_id": "artifact:operation-log-001",
+                    "type": "execution-log",
+                    "digest": sha256_digest(operation_log),
+                    "locator": "demo/artifacts/operation-log.json",
+                }
+            ],
+            "integrity": {},
+        },
+        "validation": {
+            "id": "validation:metadata-enrich-001",
+            "evidence_ref": "evidence:metadata-enrich-001",
+            "provenance_ref": "prov:metadata-enrich-001",
+            "policy_ref": "policy:approved-metadata-v1",
+            "validator": "agent-evidence validate-profile",
+            "method": "schema+reference+consistency",
+            "status": "verifiable",
+        },
+    }
+    return with_recomputed_integrity(statement)
+
+
+def main() -> int:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("Step 1: object load or creation")
+    source_object = load_source_object()
+    write_json(ARTIFACTS_DIR / "input-object.json", source_object)
+    print(f"- loaded {source_object['object_id']}")
+
+    print("Step 2: profile precheck")
+    precheck_issues = profile_precheck(source_object)
+    if precheck_issues:
+        for issue in precheck_issues:
+            print(f"- {issue}")
+        return 1
+    print("- source object is ready for the minimal profile")
+
+    print("Step 3: operation call")
+    derived_object, operation_log = apply_operation(source_object)
+    write_json(ARTIFACTS_DIR / "derived-object.json", derived_object)
+    write_json(ARTIFACTS_DIR / "operation-log.json", operation_log)
+    print(f"- emitted {derived_object['object_id']}")
+
+    print("Step 4: evidence generation")
+    statement = build_statement(source_object, derived_object, operation_log)
+    statement_path = ARTIFACTS_DIR / "minimal-profile-evidence.json"
+    write_json(statement_path, statement)
+    print(f"- wrote {statement_path.name}")
+
+    print("Step 5: validator verification")
+    report = validate_profile_file(statement_path)
+    report_path = ARTIFACTS_DIR / "validation-report.json"
+    write_json(report_path, report)
+    for line in render_summary_lines(
+        {
+            "ok": report["ok"],
+            "profile": report["profile"],
+            "source": report["source"],
+            "issue_count": report["issue_count"],
+            "issues": [issue for stage in report["stages"] for issue in stage["issues"]],
+        }
+    ):
+        print(f"- {line}")
+
+    print("Step 6: output verification result")
+    print(f"- evidence: {statement_path}")
+    print(f"- report:   {report_path}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demo/scenario.md
+++ b/demo/scenario.md
@@ -1,0 +1,31 @@
+# Scenario
+
+## Name
+
+Metadata enrichment for one client note object.
+
+## Goal
+
+Show one minimal closed loop where an agent transforms one input object into one
+derived output object under an explicit metadata policy, emits evidence, and
+gets independently validated.
+
+## Policy Boundary
+
+- Only approved metadata fields may be added.
+- The note body must remain unchanged.
+
+## Chosen Operation
+
+`metadata.enrich`
+
+The operation reads one client note, adds reviewed metadata tags, and emits one
+derived note object plus one operation log artifact.
+
+## Expected Outputs
+
+- `input-object.json`
+- `derived-object.json`
+- `operation-log.json`
+- `minimal-profile-evidence.json`
+- `validation-report.json`

--- a/docs/ACCEPTANCE-CHECKLIST.md
+++ b/docs/ACCEPTANCE-CHECKLIST.md
@@ -1,0 +1,66 @@
+# ACCEPTANCE CHECKLIST
+
+## 1. Profile 文档是否边界清楚，字段、关系、合规/失败条件完整
+
+- 状态：PASS
+- 证据文件：
+  - `spec/execution-evidence-operation-accountability-profile-v0.1.md`
+  - `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- 还差什么：
+  - 无阻塞缺口。
+- 你准备怎么补：
+  - 当前不再扩 scope，后续只在同一 profile 名称下做窄增量修订。
+
+## 2. Schema、examples、validator 三者是否严格一致
+
+- 状态：PASS
+- 证据文件：
+  - `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+  - `examples/minimal-valid-evidence.json`
+  - `examples/invalid-missing-required.json`
+  - `examples/invalid-unclosed-reference.json`
+  - `examples/invalid-policy-link-broken.json`
+  - `agent_evidence/oap.py`
+  - `tests/test_operation_accountability_profile.py`
+- 还差什么：
+  - 无阻塞缺口。
+- 你准备怎么补：
+  - 后续如果字段有变更，继续以 schema 为锚点，同步更新样例与 validator 测试。
+
+## 3. 1 个 valid + 3 个 invalid 是否都能稳定给出预期结果，且每个 invalid 只打破 1 条主规则
+
+- 状态：PASS
+- 证据文件：
+  - `examples/README.md`
+  - `demo/expected-output.md`
+  - `tests/test_operation_accountability_profile.py`
+- 还差什么：
+  - 无阻塞缺口。
+- 你准备怎么补：
+  - 维持 staged validation 输出，继续保证 invalid 样例只命中 1 个主错误码。
+
+## 4. Demo 是否形成单链路闭环，且 README/scenario/脚本三者叙述一致
+
+- 状态：PASS
+- 证据文件：
+  - `demo/README.md`
+  - `demo/scenario.md`
+  - `demo/run_operation_accountability_demo.py`
+  - `demo/expected-output.md`
+- 还差什么：
+  - 无阻塞缺口。
+- 你准备怎么补：
+  - 当前只保留单链路 metadata enrichment 场景，不另开第二条主线。
+
+## 5. 中文 brief 与英文 abstract 是否与 spec/validator/demo 保持同一术语，不漂移
+
+- 状态：PASS
+- 证据文件：
+  - `docs/research-brief-zh.md`
+  - `docs/abstract-en.md`
+  - `README.md`
+  - `docs/STATUS.md`
+- 还差什么：
+  - 历史仓库中仍保留旧的 `Execution Evidence Object` 和 `Agent Evidence Profile` 表述，但已与本轮 v0.1 最小路径分开说明，不构成本轮阻塞。
+- 你准备怎么补：
+  - 后续继续把 v0.1 最小路径限定为 `Execution Evidence and Operation Accountability Profile v0.1`、operation accountability statement、validation report 这组术语。

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,101 @@
+# 当前状态
+
+## 仓库现状摘要
+- 已有资产：`spec/`、`schema/`、`examples/`、`scripts/`、`tests/`、`submission/`、`agent_evidence/cli`。
+- 已有实现：`execution-evidence-object` 原型、`agent_evidence.aep` bundle 校验链、若干导出和验证命令。
+- 缺失资产：面向 operation accountability 的最小 profile、与该 profile 对应的样例集、专用验证入口、闭环 demo、面向当前主题的简明文稿。
+- 可直接复用部分：现有 Python 技术栈、`click` CLI、`jsonschema`、测试框架、`spec/schema/examples` 提案层、`scripts` 演示层。
+- 最小新增实现路径：在现有目录中新增 profile 规范与 schema，扩充 `examples/`，在现有 Python 包和 CLI 中增加校验器，再补一个单链路 `demo/` 目录和两份文稿。
+- 当前建议技术栈：Python 3.11 + `jsonschema` + 现有 `click` CLI + `pytest`。
+
+## 里程碑状态
+- M1 仓库扫描与计划：已完成
+- M2 最小 profile 与 schema：已完成
+- M3 样例集：已完成
+- M4 validator 与 CLI：已完成
+- M5 demo 与文稿：已完成
+
+## 当前落地产物
+- profile 规范：`spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- schema：`schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- 样例：`examples/minimal-valid-evidence.json` 及 3 个 invalid 样例
+- validator：`agent_evidence/oap.py` 与 CLI 命令 `agent-evidence validate-profile <file>`
+- demo：`demo/run_operation_accountability_demo.py`
+- 文稿：`docs/research-brief-zh.md`、`docs/abstract-en.md`
+
+## 已验证结果
+- `./.venv/bin/ruff check agent_evidence/oap.py agent_evidence/cli/main.py demo/run_operation_accountability_demo.py tests/test_operation_accountability_profile.py` 通过
+- `./.venv/bin/python -m pytest tests/test_operation_accountability_profile.py tests/test_aep_profile.py tests/test_cli.py` 通过
+- `python3 demo/run_operation_accountability_demo.py` 通过
+- `validate-profile` 对 valid 样例返回 `ok: true`
+- `validate-profile` 对 invalid 样例返回 `ok: false` 且带明确 error code
+
+## 术语与命名统一结果
+- profile 正式名称统一为 `Execution Evidence and Operation Accountability Profile v0.1`
+- profile 标识字符串统一为 `execution-evidence-operation-accountability-profile@0.1`
+- profile 载荷统一称为 `operation accountability statement`
+- validator 输出统一称为 `validation report`
+- CLI 入口统一为 `agent-evidence validate-profile <file>`
+- 历史仓库中的 `Execution Evidence Object` 与 `Agent Evidence Profile` 保留为既有表面，不作为本轮 v0.1 最小路径命名
+
+## Known environment note
+- 现有 `.venv` 使用 Python 3.14。
+- broader test runs 和已安装 CLI 在该环境下会出现一条来自 `langchain_core` 的 warning。
+- 这条 warning 不影响本轮 minimal profile / validator / demo 的执行结果。
+
+## 当前执行原则
+- 不平行新建第二套工程。
+- 优先沿用现有 Python 包、CLI、tests、docs 结构。
+- 先交付最小闭环，再考虑更广映射。
+
+## 本轮最小验证记录
+- 命令：`./.venv/bin/ruff check agent_evidence/oap.py agent_evidence/cli/main.py demo/run_operation_accountability_demo.py tests/test_operation_accountability_profile.py`
+  - 结果：`All checks passed!`
+  - 是否通过：通过
+- 命令：`./.venv/bin/python -m pytest tests/test_operation_accountability_profile.py tests/test_aep_profile.py tests/test_cli.py`
+  - 结果：`18 passed, 1 warning in 1.16s`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/minimal-valid-evidence.json`
+  - 结果：`ok: true`, `issue_count: 0`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-missing-required.json`
+  - 结果：`ok: false`, primary error code `schema_violation`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-unclosed-reference.json`
+  - 结果：`ok: false`, primary error code `unresolved_output_ref`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-policy-link-broken.json`
+  - 结果：`ok: false`, primary error code `unresolved_evidence_policy_ref`
+  - 是否通过：通过
+- 命令：`python3 demo/run_operation_accountability_demo.py`
+  - 结果：demo 闭环执行完成，末尾输出 `PASS execution-evidence-operation-accountability-profile@0.1 ...`
+  - 是否通过：通过
+
+## 本轮仍残留的问题
+- `.venv` 的 Python 3.14 环境会带出一条 `langchain_core` warning。
+- 仓库内仍保留历史 `Execution Evidence Object` / `Agent Evidence Profile` 资料；本轮没有重写这些既有表面，只通过 README 和状态文档把 v0.1 最小路径与其分开说明。
+
+## 第三轮发布前复验
+- 命令：`./.venv/bin/ruff check agent_evidence/oap.py agent_evidence/cli/main.py demo/run_operation_accountability_demo.py tests/test_operation_accountability_profile.py`
+  - 结果：`All checks passed!`
+  - 是否通过：通过
+- 命令：`./.venv/bin/python -m pytest tests/test_operation_accountability_profile.py tests/test_aep_profile.py tests/test_cli.py`
+  - 结果：`18 passed, 1 warning in 1.16s`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/minimal-valid-evidence.json`
+  - 结果：`ok: true`, `issue_count: 0`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-missing-required.json`
+  - 结果：`ok: false`, primary error code `schema_violation`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-unclosed-reference.json`
+  - 结果：`ok: false`, primary error code `unresolved_output_ref`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-policy-link-broken.json`
+  - 结果：`ok: false`, primary error code `unresolved_evidence_policy_ref`
+  - 是否通过：通过
+- 命令：`python3 demo/run_operation_accountability_demo.py`
+  - 结果：demo 闭环执行完成，末尾输出 `PASS execution-evidence-operation-accountability-profile@0.1 ...`
+  - 是否通过：通过
+- 仍残留的问题：
+  - `.venv` 的 Python 3.14 环境 warning 仍存在，但不影响本轮交付判断

--- a/docs/abstract-en.md
+++ b/docs/abstract-en.md
@@ -1,0 +1,38 @@
+# Abstract
+
+AI runtime traces are useful for debugging, but they do not automatically
+provide operation-level accountability for FDO-based agent systems. A reviewer
+may still be unable to answer a bounded set of questions: who executed an
+operation, which object was acted on, which policy constrained the action, how
+inputs and outputs were referenced, what evidence was emitted, and how an
+independent third party can verify the statement. This repository addresses
+that gap with a deliberately minimal artifact rather than a general governance
+platform.
+
+We introduce Execution Evidence and Operation Accountability Profile v0.1, a
+small JSON profile for one operation accountability statement. The profile keeps five sections
+in focus: operation, policy, provenance, evidence, and validation. It avoids
+registry design, full cryptographic infrastructure, and multi-agent governance
+abstractions. Instead, it defines a compact accountability statement with explicit
+internal references and a bounded integrity surface. The profile requires a
+named actor, a primary subject object, an operation record, a governing policy
+with constraint references, provenance links, evidence references for inputs
+and outputs, and a validation block that identifies the verifier pathway.
+
+The implementation contribution is a profile-aware validator integrated into the
+existing Python and CLI surface of this repository. The validator checks four
+properties required for a minimal accountability loop: structural completeness,
+required fields, reference closure, and consistency across policy, provenance,
+and evidence links. It also recomputes a small integrity set consisting of
+reference, artifact, and statement digests. The output remains intentionally
+simple: machine-readable JSON, explicit error codes, and a short human-readable
+summary inside one validation report.
+
+The repository also includes one valid example, three invalid examples that
+each intentionally break a single major rule class, and one runnable demo. The
+demo uses a policy-constrained metadata enrichment scenario in which one input
+object is loaded, transformed into one derived object, wrapped into an
+accountability statement, and then validated end to end. The result is not a
+claim of formal standard adoption. It is a reproducible minimal specimen for
+discussing execution evidence and operation accountability with a concrete,
+testable artifact rather than a broad architectural narrative.

--- a/docs/research-brief-zh.md
+++ b/docs/research-brief-zh.md
@@ -1,0 +1,50 @@
+# 研究简报
+
+## 问题
+
+现有 AI 运行日志有助于调试，但它们通常不能直接回答一个更关键的问题：某个 agent
+究竟在什么约束下，对哪个对象执行了什么操作，并留下了哪些可复核的证据。对于
+FDO 相关场景，这个 accountability gap 会直接影响对象派生、责任归属和第三方复核。
+
+## 本轮贡献
+
+本轮不做泛化治理平台，只补一个最小闭环：
+
+- 一个最小 `Execution Evidence and Operation Accountability Profile v0.1`
+- 一个 profile-aware validator
+- 一条单链路 demo
+- 两类文稿骨架
+
+这个 profile 只围绕五个部分展开：`operation`、`policy`、`provenance`、`evidence`
+和 `validation`。字段被压缩到最小，但仍然能够回答谁执行、对什么对象执行、受什么
+约束、输入输出如何引用、结果是什么、第三方如何验证。
+
+## 产物
+
+- `spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- `examples/minimal-valid-evidence.json` 及 3 个 invalid 样例
+- `agent-evidence validate-profile <file>`
+- `demo/run_operation_accountability_demo.py`
+- `demo/artifacts/validation-report.json`
+
+## 可验证性
+
+validator 至少做四件事：
+
+- 结构完整性检查
+- 必填字段检查
+- 引用闭合检查
+- policy / provenance / evidence 关联一致性检查
+
+同时还会重算最小完整性 digest，避免 profile 只是“结构对了”但证据材料已经漂移。
+validator 的输出以 validation report 为主，同时带 machine-readable JSON、
+error code 和简短摘要。
+
+## 下一步
+
+下一步不应立刻扩成大而全体系，而应先做三件小事：
+
+- 增补更多受控场景样例
+- 明确与现有 AEP bundle 的桥接方式
+- 在不增加结构复杂度的前提下，补更稳定的第三方验证约定

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Operation Accountability Statement Examples
+
+These examples target
+`execution-evidence-operation-accountability-profile@0.1` and are intended to
+produce one validation report per file.
+
+## Files
+
+- `minimal-valid-evidence.json`
+  - Passes schema, reference closure, policy/provenance/evidence consistency,
+    and integrity recomputation.
+- `invalid-missing-required.json`
+  - Fails because `validation.method` is intentionally removed.
+  - Main broken rule: required field completeness.
+- `invalid-unclosed-reference.json`
+  - Fails because the operation output reference points to `ref:missing-output`,
+    which is not defined in `evidence.references`.
+  - Main broken rule: reference closure.
+- `invalid-policy-link-broken.json`
+  - Fails because `evidence.policy_ref` points to `policy:stale-metadata-v1`
+    instead of the declared `policy.id`.
+  - Main broken rule: policy/evidence link consistency.
+
+## Validate
+
+```bash
+agent-evidence validate-profile examples/minimal-valid-evidence.json
+agent-evidence validate-profile examples/invalid-missing-required.json
+agent-evidence validate-profile examples/invalid-unclosed-reference.json
+agent-evidence validate-profile examples/invalid-policy-link-broken.json
+```

--- a/examples/invalid-missing-required.json
+++ b/examples/invalid-missing-required.json
@@ -1,0 +1,110 @@
+{
+  "actor": {
+    "id": "actor:metadata-enricher",
+    "name": "metadata-enricher",
+    "runtime": "openai-agents",
+    "type": "agent"
+  },
+  "constraints": [
+    {
+      "description": "Only approved metadata fields may be added.",
+      "id": "constraint:approved-fields"
+    },
+    {
+      "description": "The note body must remain unchanged.",
+      "id": "constraint:no-content-rewrite"
+    }
+  ],
+  "evidence": {
+    "artifacts": [
+      {
+        "artifact_id": "artifact:operation-log-001",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": "urn:demo:operation-log-001",
+        "type": "execution-log"
+      }
+    ],
+    "id": "evidence:metadata-enrich-001",
+    "integrity": {
+      "artifacts_digest": "sha256:d0470d93af9a5d6df99bf51369de7656ae8c84e8c65e9c1301cf6b095ea5010d",
+      "references_digest": "sha256:60ae1db47aa67231dd84e0c77a7d5a5a470e7f4474bee9922fb2a78499f75dfc",
+      "statement_digest": "sha256:a1ed81dc475aa6c0c82e30487c48c4ec31a800869220aeedfa871ebc03928a89"
+    },
+    "operation_ref": "op:metadata-enrich-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "references": [
+      {
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": "urn:demo:client-note-001",
+        "object_id": "obj:client-note-001",
+        "ref_id": "ref:input-note",
+        "role": "input"
+      },
+      {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": "urn:demo:client-note-001-derived",
+        "object_id": "obj:client-note-001-derived",
+        "ref_id": "ref:output-note",
+        "role": "output"
+      }
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "operation": {
+    "description": "Add approved metadata tags to one client note object.",
+    "id": "op:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "output_refs": [
+      "ref:output-note"
+    ],
+    "policy_ref": "policy:approved-metadata-v1",
+    "result": {
+      "status": "succeeded",
+      "summary": "one derived note object emitted"
+    },
+    "subject_ref": "obj:client-note-001",
+    "type": "metadata.enrich"
+  },
+  "policy": {
+    "constraint_refs": [
+      "constraint:approved-fields",
+      "constraint:no-content-rewrite"
+    ],
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy"
+  },
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "provenance": {
+    "actor_ref": "actor:metadata-enricher",
+    "id": "prov:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "operation_ref": "op:metadata-enrich-001",
+    "output_refs": [
+      "ref:output-note"
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "statement_id": "eeoap:metadata-demo-001",
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "type": "fdo-record"
+  },
+  "timestamp": "2026-03-30T00:00:00Z",
+  "validation": {
+    "evidence_ref": "evidence:metadata-enrich-001",
+    "id": "validation:metadata-enrich-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "provenance_ref": "prov:metadata-enrich-001",
+    "status": "verifiable",
+    "validator": "agent-evidence validate-profile"
+  }
+}

--- a/examples/invalid-policy-link-broken.json
+++ b/examples/invalid-policy-link-broken.json
@@ -1,0 +1,111 @@
+{
+  "actor": {
+    "id": "actor:metadata-enricher",
+    "name": "metadata-enricher",
+    "runtime": "openai-agents",
+    "type": "agent"
+  },
+  "constraints": [
+    {
+      "description": "Only approved metadata fields may be added.",
+      "id": "constraint:approved-fields"
+    },
+    {
+      "description": "The note body must remain unchanged.",
+      "id": "constraint:no-content-rewrite"
+    }
+  ],
+  "evidence": {
+    "artifacts": [
+      {
+        "artifact_id": "artifact:operation-log-001",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": "urn:demo:operation-log-001",
+        "type": "execution-log"
+      }
+    ],
+    "id": "evidence:metadata-enrich-001",
+    "integrity": {
+      "artifacts_digest": "sha256:d0470d93af9a5d6df99bf51369de7656ae8c84e8c65e9c1301cf6b095ea5010d",
+      "references_digest": "sha256:60ae1db47aa67231dd84e0c77a7d5a5a470e7f4474bee9922fb2a78499f75dfc",
+      "statement_digest": "sha256:a1ed81dc475aa6c0c82e30487c48c4ec31a800869220aeedfa871ebc03928a89"
+    },
+    "operation_ref": "op:metadata-enrich-001",
+    "policy_ref": "policy:stale-metadata-v1",
+    "references": [
+      {
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": "urn:demo:client-note-001",
+        "object_id": "obj:client-note-001",
+        "ref_id": "ref:input-note",
+        "role": "input"
+      },
+      {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": "urn:demo:client-note-001-derived",
+        "object_id": "obj:client-note-001-derived",
+        "ref_id": "ref:output-note",
+        "role": "output"
+      }
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "operation": {
+    "description": "Add approved metadata tags to one client note object.",
+    "id": "op:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "output_refs": [
+      "ref:output-note"
+    ],
+    "policy_ref": "policy:approved-metadata-v1",
+    "result": {
+      "status": "succeeded",
+      "summary": "one derived note object emitted"
+    },
+    "subject_ref": "obj:client-note-001",
+    "type": "metadata.enrich"
+  },
+  "policy": {
+    "constraint_refs": [
+      "constraint:approved-fields",
+      "constraint:no-content-rewrite"
+    ],
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy"
+  },
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "provenance": {
+    "actor_ref": "actor:metadata-enricher",
+    "id": "prov:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "operation_ref": "op:metadata-enrich-001",
+    "output_refs": [
+      "ref:output-note"
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "statement_id": "eeoap:metadata-demo-001",
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "type": "fdo-record"
+  },
+  "timestamp": "2026-03-30T00:00:00Z",
+  "validation": {
+    "evidence_ref": "evidence:metadata-enrich-001",
+    "id": "validation:metadata-enrich-001",
+    "method": "schema+reference+consistency",
+    "policy_ref": "policy:approved-metadata-v1",
+    "provenance_ref": "prov:metadata-enrich-001",
+    "status": "verifiable",
+    "validator": "agent-evidence validate-profile"
+  }
+}

--- a/examples/invalid-unclosed-reference.json
+++ b/examples/invalid-unclosed-reference.json
@@ -1,0 +1,111 @@
+{
+  "actor": {
+    "id": "actor:metadata-enricher",
+    "name": "metadata-enricher",
+    "runtime": "openai-agents",
+    "type": "agent"
+  },
+  "constraints": [
+    {
+      "description": "Only approved metadata fields may be added.",
+      "id": "constraint:approved-fields"
+    },
+    {
+      "description": "The note body must remain unchanged.",
+      "id": "constraint:no-content-rewrite"
+    }
+  ],
+  "evidence": {
+    "artifacts": [
+      {
+        "artifact_id": "artifact:operation-log-001",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": "urn:demo:operation-log-001",
+        "type": "execution-log"
+      }
+    ],
+    "id": "evidence:metadata-enrich-001",
+    "integrity": {
+      "artifacts_digest": "sha256:d0470d93af9a5d6df99bf51369de7656ae8c84e8c65e9c1301cf6b095ea5010d",
+      "references_digest": "sha256:60ae1db47aa67231dd84e0c77a7d5a5a470e7f4474bee9922fb2a78499f75dfc",
+      "statement_digest": "sha256:6c5a09e439330384c238c545d19e81545a8c08406c35ebebad15f6b8b7c50821"
+    },
+    "operation_ref": "op:metadata-enrich-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "references": [
+      {
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": "urn:demo:client-note-001",
+        "object_id": "obj:client-note-001",
+        "ref_id": "ref:input-note",
+        "role": "input"
+      },
+      {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": "urn:demo:client-note-001-derived",
+        "object_id": "obj:client-note-001-derived",
+        "ref_id": "ref:output-note",
+        "role": "output"
+      }
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "operation": {
+    "description": "Add approved metadata tags to one client note object.",
+    "id": "op:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "output_refs": [
+      "ref:missing-output"
+    ],
+    "policy_ref": "policy:approved-metadata-v1",
+    "result": {
+      "status": "succeeded",
+      "summary": "one derived note object emitted"
+    },
+    "subject_ref": "obj:client-note-001",
+    "type": "metadata.enrich"
+  },
+  "policy": {
+    "constraint_refs": [
+      "constraint:approved-fields",
+      "constraint:no-content-rewrite"
+    ],
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy"
+  },
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "provenance": {
+    "actor_ref": "actor:metadata-enricher",
+    "id": "prov:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "operation_ref": "op:metadata-enrich-001",
+    "output_refs": [
+      "ref:missing-output"
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "statement_id": "eeoap:metadata-demo-001",
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "type": "fdo-record"
+  },
+  "timestamp": "2026-03-30T00:00:00Z",
+  "validation": {
+    "evidence_ref": "evidence:metadata-enrich-001",
+    "id": "validation:metadata-enrich-001",
+    "method": "schema+reference+consistency",
+    "policy_ref": "policy:approved-metadata-v1",
+    "provenance_ref": "prov:metadata-enrich-001",
+    "status": "verifiable",
+    "validator": "agent-evidence validate-profile"
+  }
+}

--- a/examples/minimal-valid-evidence.json
+++ b/examples/minimal-valid-evidence.json
@@ -1,0 +1,111 @@
+{
+  "actor": {
+    "id": "actor:metadata-enricher",
+    "name": "metadata-enricher",
+    "runtime": "openai-agents",
+    "type": "agent"
+  },
+  "constraints": [
+    {
+      "description": "Only approved metadata fields may be added.",
+      "id": "constraint:approved-fields"
+    },
+    {
+      "description": "The note body must remain unchanged.",
+      "id": "constraint:no-content-rewrite"
+    }
+  ],
+  "evidence": {
+    "artifacts": [
+      {
+        "artifact_id": "artifact:operation-log-001",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": "urn:demo:operation-log-001",
+        "type": "execution-log"
+      }
+    ],
+    "id": "evidence:metadata-enrich-001",
+    "integrity": {
+      "artifacts_digest": "sha256:d0470d93af9a5d6df99bf51369de7656ae8c84e8c65e9c1301cf6b095ea5010d",
+      "references_digest": "sha256:60ae1db47aa67231dd84e0c77a7d5a5a470e7f4474bee9922fb2a78499f75dfc",
+      "statement_digest": "sha256:a1ed81dc475aa6c0c82e30487c48c4ec31a800869220aeedfa871ebc03928a89"
+    },
+    "operation_ref": "op:metadata-enrich-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "references": [
+      {
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": "urn:demo:client-note-001",
+        "object_id": "obj:client-note-001",
+        "ref_id": "ref:input-note",
+        "role": "input"
+      },
+      {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": "urn:demo:client-note-001-derived",
+        "object_id": "obj:client-note-001-derived",
+        "ref_id": "ref:output-note",
+        "role": "output"
+      }
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "operation": {
+    "description": "Add approved metadata tags to one client note object.",
+    "id": "op:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "output_refs": [
+      "ref:output-note"
+    ],
+    "policy_ref": "policy:approved-metadata-v1",
+    "result": {
+      "status": "succeeded",
+      "summary": "one derived note object emitted"
+    },
+    "subject_ref": "obj:client-note-001",
+    "type": "metadata.enrich"
+  },
+  "policy": {
+    "constraint_refs": [
+      "constraint:approved-fields",
+      "constraint:no-content-rewrite"
+    ],
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy"
+  },
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "provenance": {
+    "actor_ref": "actor:metadata-enricher",
+    "id": "prov:metadata-enrich-001",
+    "input_refs": [
+      "ref:input-note"
+    ],
+    "operation_ref": "op:metadata-enrich-001",
+    "output_refs": [
+      "ref:output-note"
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "statement_id": "eeoap:metadata-demo-001",
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "type": "fdo-record"
+  },
+  "timestamp": "2026-03-30T00:00:00Z",
+  "validation": {
+    "evidence_ref": "evidence:metadata-enrich-001",
+    "id": "validation:metadata-enrich-001",
+    "method": "schema+reference+consistency",
+    "policy_ref": "policy:approved-metadata-v1",
+    "provenance_ref": "prov:metadata-enrich-001",
+    "status": "verifiable",
+    "validator": "agent-evidence validate-profile"
+  }
+}

--- a/plans/implementation-plan.md
+++ b/plans/implementation-plan.md
@@ -1,0 +1,26 @@
+# implementation plan
+
+## M1 仓库扫描与计划
+- 输入：现有 `spec/`、`schema/`、`examples/`、`scripts/`、`tests/`、CLI 结构。
+- 输出：`docs/STATUS.md`、`plans/implementation-plan.md`。
+- 验收条件：明确已有资产、缺失资产、最小新增路径、建议技术栈。
+
+## M2 最小 profile 与 schema
+- 输入：现有 `execution-evidence-object` 原型、FDO 映射文档、当前主题边界。
+- 输出：新增最小 profile 规范文档和 JSON Schema。
+- 验收条件：字段能回答谁执行、对什么对象执行、执行了什么 operation、受何 policy 约束、输入输出如何引用、结果是什么、完整性材料是什么、第三方如何验证。
+
+## M3 样例集
+- 输入：M2 产出的规范与 schema。
+- 输出：1 个 valid 样例、3 个 invalid 样例、`examples/README.md`。
+- 验收条件：每个 invalid 样例只破坏 1 条主规则，README 清楚解释通过或失败原因。
+
+## M4 validator 与 CLI
+- 输入：M2 schema、M3 样例、现有 Python 包和 CLI。
+- 输出：可复用的 profile 校验模块、CLI 命令、测试。
+- 验收条件：至少覆盖结构完整性、必填字段、引用闭合、policy/provenance/evidence 关联一致性；输出 JSON 结果、人类可读摘要、明确 error code。
+
+## M5 demo 与文稿
+- 输入：M2-M4 产物。
+- 输出：单链路 `demo/` 闭环、`docs/research-brief-zh.md`、`docs/abstract-en.md`。
+- 验收条件：demo 可运行并打印验证结果；文稿聚焦 minimal profile / validator / demo / accountability gap，不扩展成宏大平台叙事。

--- a/schema/execution-evidence-operation-accountability-profile-v0.1.schema.json
+++ b/schema/execution-evidence-operation-accountability-profile-v0.1.schema.json
@@ -1,0 +1,442 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/agent-evidence/execution-evidence-operation-accountability-profile-v0.1.schema.json",
+  "title": "ExecutionEvidenceOperationAccountabilityProfileV0_1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile",
+    "statement_id",
+    "timestamp",
+    "actor",
+    "subject",
+    "operation",
+    "policy",
+    "constraints",
+    "provenance",
+    "evidence",
+    "validation"
+  ],
+  "properties": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "execution-evidence-operation-accountability-profile"
+        },
+        "version": {
+          "type": "string",
+          "const": "0.1"
+        }
+      }
+    },
+    "statement_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "name",
+        "runtime"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "digest",
+        "locator"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "locator": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "subject_ref",
+        "policy_ref",
+        "input_refs",
+        "output_refs",
+        "result"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "subject_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "output_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "summary"
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "succeeded",
+                "failed"
+              ]
+            },
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "constraint_refs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "constraint_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "description"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "actor_ref",
+        "operation_ref",
+        "subject_ref",
+        "input_refs",
+        "output_refs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "subject_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "output_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "subject_ref",
+        "operation_ref",
+        "policy_ref",
+        "references",
+        "artifacts",
+        "integrity"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "subject_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "references": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "ref_id",
+              "role",
+              "object_id",
+              "digest",
+              "locator"
+            ],
+            "properties": {
+              "ref_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "input",
+                  "output"
+                ]
+              },
+              "object_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$"
+              },
+              "locator": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "artifact_id",
+              "type",
+              "digest",
+              "locator"
+            ],
+            "properties": {
+              "artifact_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$"
+              },
+              "locator": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "integrity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "references_digest",
+            "artifacts_digest",
+            "statement_digest"
+          ],
+          "properties": {
+            "references_digest": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "artifacts_digest": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "statement_digest": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "evidence_ref",
+        "provenance_ref",
+        "policy_ref",
+        "validator",
+        "method",
+        "status"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provenance_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "validator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "verifiable",
+            "unverifiable"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/execution-evidence-operation-accountability-profile-v0.1.md
+++ b/spec/execution-evidence-operation-accountability-profile-v0.1.md
@@ -1,0 +1,256 @@
+# Execution Evidence and Operation Accountability Profile v0.1
+
+## 1. Scope
+
+This profile defines one minimal operation accountability statement for a
+single
+operation executed within an FDO-based agent system.
+
+It is intentionally narrow. It covers only:
+
+- who executed
+- which subject object was acted on
+- which operation was invoked
+- which policy and constraints governed the action
+- how input and output objects were referenced
+- what evidence and integrity material were emitted
+- how a third party can verify the statement
+
+It does not attempt to define a general registry, a full governance platform,
+or a full cryptographic trust fabric.
+
+## 2. Core Object Model
+
+One operation accountability statement consists of the following top-level
+sections:
+
+- `profile`: fixed profile identity and version
+- `statement_id`: stable identifier for the accountability statement
+- `timestamp`: statement emission time
+- `actor`: the executor
+- `subject`: the primary object acted on
+- `operation`: the action and its result
+- `policy`: the governing policy
+- `constraints`: the concrete rule set referenced by the policy
+- `provenance`: the linkage between actor, subject, operation, and I/O refs
+- `evidence`: the referenced materials and integrity digests
+- `validation`: how an independent verifier checks the statement
+
+## 3. Required Fields
+
+The minimal required fields are:
+
+- `profile.name`
+- `profile.version`
+- `statement_id`
+- `timestamp`
+- `actor.id`
+- `actor.type`
+- `actor.name`
+- `actor.runtime`
+- `subject.id`
+- `subject.type`
+- `subject.digest`
+- `subject.locator`
+- `operation.id`
+- `operation.type`
+- `operation.subject_ref`
+- `operation.policy_ref`
+- `operation.input_refs`
+- `operation.output_refs`
+- `operation.result.status`
+- `operation.result.summary`
+- `policy.id`
+- `policy.name`
+- `policy.constraint_refs`
+- `constraints[].id`
+- `constraints[].description`
+- `provenance.id`
+- `provenance.actor_ref`
+- `provenance.operation_ref`
+- `provenance.subject_ref`
+- `provenance.input_refs`
+- `provenance.output_refs`
+- `evidence.id`
+- `evidence.subject_ref`
+- `evidence.operation_ref`
+- `evidence.policy_ref`
+- `evidence.references[]`
+- `evidence.artifacts[]`
+- `evidence.integrity.references_digest`
+- `evidence.integrity.artifacts_digest`
+- `evidence.integrity.statement_digest`
+- `validation.id`
+- `validation.evidence_ref`
+- `validation.provenance_ref`
+- `validation.policy_ref`
+- `validation.validator`
+- `validation.method`
+- `validation.status`
+
+## 4. Optional Fields
+
+The profile keeps optional fields to a minimum:
+
+- `operation.description`
+
+The required locator fields remain flexible in value shape:
+
+- `subject.locator` may be a URI, path, or persistent identifier placeholder
+- `evidence.references[].locator` may be a URI, path, or persistent identifier placeholder
+- `evidence.artifacts[].locator` may be a URI, path, or persistent identifier placeholder
+
+No optional extension fields are required for conformance in v0.1.
+
+## 5. Field Relationships
+
+The minimum link rules are:
+
+- `operation.subject_ref` must equal `subject.id`
+- `operation.policy_ref` must equal `policy.id`
+- every `policy.constraint_refs[]` value must resolve to one `constraints[].id`
+- every `operation.input_refs[]` and `operation.output_refs[]` value must resolve to one `evidence.references[].ref_id`
+- `provenance.actor_ref` must equal `actor.id`
+- `provenance.operation_ref` must equal `operation.id`
+- `provenance.subject_ref` must equal `subject.id`
+- `provenance.input_refs` must match `operation.input_refs`
+- `provenance.output_refs` must match `operation.output_refs`
+- `evidence.subject_ref` must equal `subject.id`
+- `evidence.operation_ref` must equal `operation.id`
+- `evidence.policy_ref` must equal `policy.id`
+- `validation.evidence_ref` must equal `evidence.id`
+- `validation.provenance_ref` must equal `provenance.id`
+- `validation.policy_ref` must equal `policy.id`
+
+## 6. Compliance Conditions
+
+An operation accountability statement is compliant only if all of the
+following hold:
+
+1. `profile.name` is `execution-evidence-operation-accountability-profile`.
+2. `profile.version` is `0.1`.
+3. The JSON instance satisfies the schema.
+4. Every internal reference resolves to an existing local identifier.
+5. Input refs point to evidence references with role `input`.
+6. Output refs point to evidence references with role `output`.
+7. Policy, provenance, and evidence carry a consistent linkage to the same
+   operation statement.
+8. `evidence.integrity.references_digest` equals the canonical digest of
+   `evidence.references`.
+9. `evidence.integrity.artifacts_digest` equals the canonical digest of
+   `evidence.artifacts`.
+10. `evidence.integrity.statement_digest` equals the canonical digest of the
+    statement core: `actor`, `subject`, `operation`, `policy`, `constraints`,
+    and `provenance`.
+
+## 7. Failure Conditions
+
+Validation fails when at least one of the following occurs:
+
+- a required field is missing
+- a field shape violates the schema
+- a local reference is unclosed
+- an input ref points to a non-input evidence reference
+- an output ref points to a non-output evidence reference
+- `policy`, `provenance`, and `evidence` do not agree on the linked entities
+- any integrity digest fails recomputation
+
+## 8. Minimal JSON Expression Suggestion
+
+```json
+{
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "statement_id": "eeoap:demo-001",
+  "timestamp": "2026-03-30T00:00:00Z",
+  "actor": {
+    "id": "actor:metadata-enricher",
+    "type": "agent",
+    "name": "metadata-enricher",
+    "runtime": "openai-agents"
+  },
+  "subject": {
+    "id": "obj:note-001",
+    "type": "fdo-record",
+    "digest": "sha256:<64 lowercase hex chars>",
+    "locator": "urn:demo:note-001"
+  },
+  "operation": {
+    "id": "op:metadata-enrich-001",
+    "type": "metadata.enrich",
+    "subject_ref": "obj:note-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "input_refs": ["ref:input-note"],
+    "output_refs": ["ref:output-note"],
+    "result": {
+      "status": "succeeded",
+      "summary": "one derived object emitted"
+    }
+  },
+  "policy": {
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy",
+    "constraint_refs": ["constraint:approved-fields"]
+  },
+  "constraints": [
+    {
+      "id": "constraint:approved-fields",
+      "description": "Only approved metadata fields may be added."
+    }
+  ],
+  "provenance": {
+    "id": "prov:demo-001",
+    "actor_ref": "actor:metadata-enricher",
+    "operation_ref": "op:metadata-enrich-001",
+    "subject_ref": "obj:note-001",
+    "input_refs": ["ref:input-note"],
+    "output_refs": ["ref:output-note"]
+  },
+  "evidence": {
+    "id": "evidence:demo-001",
+    "subject_ref": "obj:note-001",
+    "operation_ref": "op:metadata-enrich-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "references": [
+      {
+        "ref_id": "ref:input-note",
+        "role": "input",
+        "object_id": "obj:note-001",
+        "digest": "sha256:<64 lowercase hex chars>",
+        "locator": "urn:demo:note-001"
+      },
+      {
+        "ref_id": "ref:output-note",
+        "role": "output",
+        "object_id": "obj:note-001-derived",
+        "digest": "sha256:<64 lowercase hex chars>",
+        "locator": "urn:demo:note-001-derived"
+      }
+    ],
+    "artifacts": [
+      {
+        "artifact_id": "artifact:op-log-001",
+        "type": "execution-log",
+        "digest": "sha256:<64 lowercase hex chars>",
+        "locator": "urn:demo:op-log-001"
+      }
+    ],
+    "integrity": {
+      "references_digest": "sha256:<64 lowercase hex chars>",
+      "artifacts_digest": "sha256:<64 lowercase hex chars>",
+      "statement_digest": "sha256:<64 lowercase hex chars>"
+    }
+  },
+  "validation": {
+    "id": "validation:demo-001",
+    "evidence_ref": "evidence:demo-001",
+    "provenance_ref": "prov:demo-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "validator": "agent-evidence validate-profile",
+    "method": "schema+reference+consistency",
+    "status": "verifiable"
+  }
+}
+```

--- a/submission/commit-and-pr-note.md
+++ b/submission/commit-and-pr-note.md
@@ -1,0 +1,42 @@
+# Commit And PR Note
+
+## 1. Suggested commit message
+
+```text
+Freeze v0.1 operation accountability package and handoff docs
+```
+
+## 2. Suggested PR title
+
+```text
+Freeze v0.1 operation accountability package for handoff
+```
+
+## 3. Suggested PR description
+
+```text
+This PR freezes the current v0.1 operation accountability package into a handoff-ready surface.
+
+It adds the minimal profile spec/schema path, profile-aware validation examples and tests, the single-chain demo, and the release/handoff documentation needed for commit, review, and external sharing.
+```
+
+## 4. 本轮新增 / 修改内容摘要
+
+- 冻结 `Execution Evidence and Operation Accountability Profile v0.1`
+- 补齐 valid / invalid 样例与 validator 测试
+- 固化单链路 demo 与 expected output
+- 增加 acceptance / package note / release readiness / final handoff / package manifest
+- 在 README 中补当前 v0.1 路径和最短运行入口
+
+## 5. 验证结果摘要
+
+- `ruff check` 通过
+- profile 相关 `pytest` 通过
+- valid 样例验证通过
+- 3 个 invalid 样例均返回预期主错误码
+- demo 闭环执行通过
+
+## 6. 已知非阻塞问题摘要
+
+- `.venv` 的 Python 3.14 环境会带出一条 `langchain_core` warning
+- 仓库仍保留历史 `Execution Evidence Object` / `Agent Evidence Profile` 路线资料，但已与当前 v0.1 handoff 路径分开说明

--- a/submission/final-handoff.md
+++ b/submission/final-handoff.md
@@ -1,0 +1,60 @@
+# Final Handoff
+
+## 1. 这次交付解决了什么问题
+
+这次交付把一个容易停留在概念层的议题，收成了一个可运行、可验证、可演示的最小
+闭环。外部人现在可以直接看到：谁执行了什么 operation、针对哪个对象、受什么
+ policy 约束、留下了哪些 evidence，以及 validator 如何给出 validation report。
+
+## 2. 最小闭环由哪几部分组成
+
+- `Execution Evidence and Operation Accountability Profile v0.1`
+- 对应 JSON Schema
+- profile-aware validator 与 CLI 命令 `agent-evidence validate-profile`
+- 1 个 valid + 3 个 invalid 样例
+- 一条 metadata enrichment 单链路 demo
+- brief / abstract / status / acceptance / package note
+
+## 3. 仓库中最关键的入口文件有哪些
+
+- `spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- `agent_evidence/oap.py`
+- `agent_evidence/cli/main.py`
+- `examples/README.md`
+- `demo/README.md`
+- `docs/STATUS.md`
+- `docs/ACCEPTANCE-CHECKLIST.md`
+- `submission/package-manifest.md`
+
+## 4. 外部人最短怎么跑起来
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+agent-evidence validate-profile examples/minimal-valid-evidence.json
+agent-evidence validate-profile examples/invalid-missing-required.json
+agent-evidence validate-profile examples/invalid-unclosed-reference.json
+agent-evidence validate-profile examples/invalid-policy-link-broken.json
+python3 demo/run_operation_accountability_demo.py
+```
+
+如果只想先看结果，不先跑代码，先看：
+
+- `demo/expected-output.md`
+- `docs/ACCEPTANCE-CHECKLIST.md`
+- `submission/v0.1-package-note.md`
+
+## 5. 当前边界和已知不做项
+
+- 当前只覆盖单 operation accountability statement。
+- 当前不覆盖 registry、多智能体编排、全量 FDO 映射、完整密码学基础设施。
+- 当前 validator 采用 staged validation，优先报告主失败面。
+- 仓库保留历史 `Execution Evidence Object` / `Agent Evidence Profile` 资料，但它们不是这次 v0.1 handoff 的主路径。
+
+## 6. 下一轮最合理的 3 个窄扩展点
+
+- 增补 1 到 2 个同边界的受控场景样例。
+- 补一份本 profile 与现有 AEP bundle 的最小桥接说明。
+- 为 validation report 增加一个更稳定的 reviewer-facing 展示模板。

--- a/submission/package-manifest.md
+++ b/submission/package-manifest.md
@@ -1,0 +1,27 @@
+# Package Manifest
+
+## 用途 -> 文件路径
+
+- profile spec -> `spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- schema -> `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- validator 实现 -> `agent_evidence/oap.py`
+- validator CLI 入口 -> `agent_evidence/cli/main.py`
+- examples 导航 -> `examples/README.md`
+- valid example -> `examples/minimal-valid-evidence.json`
+- invalid example: missing required -> `examples/invalid-missing-required.json`
+- invalid example: unclosed reference -> `examples/invalid-unclosed-reference.json`
+- invalid example: broken policy link -> `examples/invalid-policy-link-broken.json`
+- tests -> `tests/test_operation_accountability_profile.py`
+- demo 导航 -> `demo/README.md`
+- demo scenario -> `demo/scenario.md`
+- demo expected output -> `demo/expected-output.md`
+- demo runner -> `demo/run_operation_accountability_demo.py`
+- research brief -> `docs/research-brief-zh.md`
+- abstract -> `docs/abstract-en.md`
+- status -> `docs/STATUS.md`
+- acceptance checklist -> `docs/ACCEPTANCE-CHECKLIST.md`
+- package note -> `submission/v0.1-package-note.md`
+- release readiness -> `submission/release-readiness-check.md`
+- final handoff -> `submission/final-handoff.md`
+- commit / PR note -> `submission/commit-and-pr-note.md`
+- package manifest -> `submission/package-manifest.md`

--- a/submission/release-readiness-check.md
+++ b/submission/release-readiness-check.md
@@ -1,0 +1,65 @@
+# Release Readiness Check
+
+## 1. 当前发布对象是什么
+
+- 冻结后的 `Execution Evidence and Operation Accountability Profile v0.1`
+  handoff 包。
+
+## 2. 发布范围是什么
+
+- profile spec
+- JSON Schema
+- profile-aware validator 与 CLI 入口
+- 1 个 valid + 3 个 invalid 样例
+- 单链路 demo
+- brief / abstract / status / acceptance / handoff 文档
+
+## 3. 不包含什么
+
+- 泛化治理平台
+- registry 扩展
+- 多智能体编排
+- 全量 FDO 映射
+- 完整密码学基础设施
+- 对历史 `Execution Evidence Object` / `Agent Evidence Profile` 路线的重写
+
+## 4. 阻塞项是否为 0
+
+- blocking：0
+
+## 5. 非阻塞项有哪些
+
+- `.venv` 的 Python 3.14 环境在 broader test runs 和已安装 CLI 下会出现一条
+  `langchain_core` warning。
+- 仓库中仍保留历史 `Execution Evidence Object` / `Agent Evidence Profile`
+  资料，但已与本轮 v0.1 主路径分开说明。
+
+## 6. 结论：是否建议现在提交
+
+- 建议现在提交。
+- 原因：blocking 为 0，最小验证已通过，handoff 材料已齐，剩余问题均为可交代的
+  non-blocking 项。
+
+## Latest validation
+
+- 命令：`./.venv/bin/ruff check agent_evidence/oap.py agent_evidence/cli/main.py demo/run_operation_accountability_demo.py tests/test_operation_accountability_profile.py`
+  - 结果：`All checks passed!`
+  - 是否通过：通过
+- 命令：`./.venv/bin/python -m pytest tests/test_operation_accountability_profile.py tests/test_aep_profile.py tests/test_cli.py`
+  - 结果：`18 passed, 1 warning in 1.16s`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/minimal-valid-evidence.json`
+  - 结果：`ok: true`, `issue_count: 0`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-missing-required.json`
+  - 结果：`ok: false`, primary error code `schema_violation`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-unclosed-reference.json`
+  - 结果：`ok: false`, primary error code `unresolved_output_ref`
+  - 是否通过：通过
+- 命令：`./.venv/bin/agent-evidence validate-profile examples/invalid-policy-link-broken.json`
+  - 结果：`ok: false`, primary error code `unresolved_evidence_policy_ref`
+  - 是否通过：通过
+- 命令：`python3 demo/run_operation_accountability_demo.py`
+  - 结果：demo 闭环执行完成，末尾输出 `PASS execution-evidence-operation-accountability-profile@0.1 ...`
+  - 是否通过：通过

--- a/submission/v0.1-package-note.md
+++ b/submission/v0.1-package-note.md
@@ -1,0 +1,45 @@
+# v0.1 Package Note
+
+## 1. 本轮交付了什么
+
+- 一个最小 `Execution Evidence and Operation Accountability Profile v0.1`
+- 一个 profile-aware validator 与 CLI 入口
+- 1 个 valid + 3 个 invalid 样例
+- 一条单链路 demo
+- 一组可直接用于沟通和演示的文档
+
+## 2. 仓库里对应在哪些文件
+
+- 规范：`spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- Schema：`schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- Validator：`agent_evidence/oap.py`
+- CLI：`agent_evidence/cli/main.py`
+- 样例：`examples/minimal-valid-evidence.json` 与 3 个 invalid 样例
+- Demo：`demo/run_operation_accountability_demo.py`
+- 展示材料：`demo/expected-output.md`
+- 状态与验收：`docs/STATUS.md`、`docs/ACCEPTANCE-CHECKLIST.md`
+
+## 3. 如何最小复现
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+agent-evidence validate-profile examples/minimal-valid-evidence.json
+agent-evidence validate-profile examples/invalid-missing-required.json
+agent-evidence validate-profile examples/invalid-unclosed-reference.json
+agent-evidence validate-profile examples/invalid-policy-link-broken.json
+python3 demo/run_operation_accountability_demo.py
+```
+
+## 4. 当前已知边界 / 残缺点
+
+- 当前只覆盖单 operation accountability statement，不覆盖多操作编排。
+- 当前 validator 采用 staged validation，优先报告主失败面，不追求一次性展开全部次生问题。
+- 现有 `.venv` 在 Python 3.14 下做 broader test runs 时会出现一条 `langchain_core` warning，但不影响本轮 minimal profile / validator / demo。
+
+## 5. 下一轮最合理扩展点
+
+- 增补 1 到 2 个同边界的受控场景样例，不扩成新体系。
+- 明确本 profile 与现有 AEP bundle 的最小桥接文档。
+- 为 validation report 补一个更稳定的对外展示模板。

--- a/tests/test_operation_accountability_profile.py
+++ b/tests/test_operation_accountability_profile.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from agent_evidence.cli.main import main
+from agent_evidence.oap import validate_profile_file
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
+
+
+def test_valid_operation_accountability_profile_passes() -> None:
+    report = validate_profile_file(EXAMPLES / "minimal-valid-evidence.json")
+
+    assert report["ok"] is True
+    assert report["issue_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_code", "expected_issue_count"),
+    [
+        ("invalid-missing-required.json", "schema_violation", 1),
+        ("invalid-unclosed-reference.json", "unresolved_output_ref", 1),
+        ("invalid-policy-link-broken.json", "unresolved_evidence_policy_ref", 1),
+    ],
+)
+def test_invalid_operation_accountability_profiles_fail(
+    filename: str, expected_code: str, expected_issue_count: int
+) -> None:
+    report = validate_profile_file(EXAMPLES / filename)
+
+    assert report["ok"] is False
+    assert report["issue_count"] == expected_issue_count
+    issue_codes = {issue["code"] for stage in report["stages"] for issue in stage["issues"]}
+    assert expected_code in issue_codes
+
+
+def test_validate_profile_cli_command() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        ["validate-profile", str(EXAMPLES / "minimal-valid-evidence.json")],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True


### PR DESCRIPTION
This PR freezes the v0.1 minimal package for the Execution Evidence and Operation Accountability Profile for FDO-based Agent Systems.

Included in this PR:
- v0.1 profile spec and schema
- valid/invalid example set
- profile-aware validator wiring and tests
- single-chain demo and expected output notes
- status, acceptance, release-readiness, and handoff documents
- research brief (ZH) and abstract (EN)

Validation rerun:
- ruff check: passed
- pytest: 18 passed, 1 non-blocking warning
- validate-profile on 1 valid + 3 invalid examples: expected results confirmed
- demo run: passed

Known non-blocking notes:
- Python 3.14 `.venv` may emit one `langchain_core` warning
- legacy historical surfaces remain in the repo but are separated from the v0.1 path
