### PR TITLE
docs: add main entry for frozen EDC Java spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ paths.
 The historical specimen track still keeps its original DOI:
 https://doi.org/10.5281/zenodo.19055948
 
+## EDC Java spike
+
+EDC Java spike 已冻结为可引用的 augmentation-layer validation artifact。主仓入口见 [docs/edc-java-spike/README.md](docs/edc-java-spike/README.md)，冻结 summary 见 [SPIKE_FREEZE_SUMMARY.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/SPIKE_FREEZE_SUMMARY.md)。
+
 ## Fastest proof
 
 ```bash

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,6 +15,7 @@
 - M4 validator 与 CLI：已完成
 - M5 demo 与文稿：已完成
 - M7 旗舰论文规划包：已完成
+- M8 frozen EDC Java spike main-repo entry：已完成
 
 ## 当前落地产物
 - profile 规范：`spec/execution-evidence-operation-accountability-profile-v0.1.md`
@@ -160,3 +161,21 @@
   - 更完整 failure taxonomy 覆盖
   - 多场景外部有效性
   - 更强的 logs / provenance / policy / audit trail 同案比较
+
+## M8 frozen EDC Java spike main-repo entry
+- 状态：已完成
+- 定位结论：
+  - 这轮不是功能开发，也不是把整条 Java spike 并入主仓。
+  - 目标只是给已经冻结的 EDC Java spike 增加一个主仓可见、可稳定引用的入口。
+- 本轮新增或更新：
+  - `docs/edc-java-spike/README.md`
+  - `README.md`
+  - `docs/STATUS.md`
+  - `plans/implementation-plan.md`
+- 本轮收敛结果：
+  - 主仓现在能稳定指向 tag `edc-java-spike-freeze-v0.1` 下的 freeze package
+  - 入口页明确说明了这条 spike 验证了什么、为什么先停在 freeze package、以及为什么不直接 merge 整条 Java / Gradle spike
+  - 本轮没有复制 `spikes/edc-java-extension/`，没有合并 Java 代码，也没有引入新的 runtime 能力
+- 本轮核验：
+  - `git diff --check`：待提交前复验
+  - 本轮仅入口整理与文档更新，未改动 Python 主包或运行时代码，因此未额外重跑测试

--- a/docs/edc-java-spike/README.md
+++ b/docs/edc-java-spike/README.md
@@ -1,0 +1,54 @@
+# EDC Java Spike Entry
+
+## 结论
+
+这条 EDC Java spike 是 `agent-evidence` 在 dataspace / EDC control-plane 场景中的 augmentation-layer validation，不是新主线，不是 EDC 产品线，也不是要把主仓改造成 Java runtime 仓库。
+
+## 它验证了什么
+
+它验证的是一条尽量薄的 Java 接入路径是否成立：
+
+- control-plane event mapping
+- grouping / dedup
+- exporter handoff
+- runtime wiring
+- startup smoke
+- startup failure contract
+- runtime-facing exporter integration
+
+## 为什么现在先停在 freeze package
+
+因为这条线已经足够证明 augmentation layer 可行。
+
+当前更有价值的是把它变成可稳定引用的资产，而不是继续往 runtime 细节上扩。继续把 spike 做宽，只会让 scope 再次膨胀。
+
+## 为什么不直接把整条 spike 并进主功能
+
+当前更适合把它作为 freeze package 引用，而不是把整条 Java / Gradle spike 直接并入 `main`。
+
+原因很简单：
+
+1. 当前目标是可见性和可引用性，不是继续扩张。
+2. 这条线已经足够证明 augmentation layer 可行。
+3. 继续把 spike 大量并入 `main` 会再次放大 scope，并把主仓重心从当前 Python 主包拉偏。
+
+## 从哪里开始看
+
+稳定冻结 tag：`edc-java-spike-freeze-v0.1`
+
+建议阅读顺序：
+
+1. [SPIKE_FREEZE_SUMMARY.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/SPIKE_FREEZE_SUMMARY.md)
+2. [VALIDATED_SURFACES.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/VALIDATED_SURFACES.md)
+3. [UPSTREAM_HANDOFF_NOTE.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/UPSTREAM_HANDOFF_NOTE.md)
+4. [TESTING_AND_RUNBOOK.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/TESTING_AND_RUNBOOK.md)
+5. [RUNTIME_WIRING_SAMPLE.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/RUNTIME_WIRING_SAMPLE.md)
+6. [FAILURE_TRIAGE_RECIPE.md](https://github.com/joy7758/agent-evidence/blob/edc-java-spike-freeze-v0.1/spikes/edc-java-extension/FAILURE_TRIAGE_RECIPE.md)
+
+## 如何使用这个入口
+
+- 主仓读者：先看 freeze summary，再看 validated surfaces。
+- 需要对外说明的人：直接引用 upstream handoff note。
+- 需要复现实验的人：直接用 testing and runbook。
+
+这里的重点是“稳定引用”，不是“继续开发这条 Java 线”。

--- a/plans/implementation-plan.md
+++ b/plans/implementation-plan.md
@@ -56,3 +56,20 @@
   - 明确提出 minimal verification boundary、failure taxonomy、external validation agenda
   - 保持 Chinese-first、plain language、结构紧凑
   - 不修改现有 `paper/submission_tosem/`、blind package 或 review artifacts
+
+## M8 frozen EDC Java spike main-repo entry
+- 输入：
+  - 已冻结的 EDC Java spike tag：`edc-java-spike-freeze-v0.1`
+  - 当前主仓 README、`docs/STATUS.md` 与本计划文件
+  - freeze package 中的 summary / validated surfaces / handoff / runbook 文档
+- 输出：
+  - `docs/edc-java-spike/README.md`
+  - `README.md` 中的最小入口导航
+  - `docs/STATUS.md` 的入口整理里程碑
+  - 如有必要，本计划中的对应里程碑
+- 验收条件：
+  - 主仓新增一个克制的 EDC Java spike 入口页
+  - 所有 freeze package 链接都使用基于 tag `edc-java-spike-freeze-v0.1` 的稳定 GitHub 链接
+  - 明确说明当前应引用 freeze package，而不是把整条 Java spike 直接并入 `main`
+  - 不复制 `spikes/edc-java-extension/`，不合并 Java 代码，不新增运行时功能
+  - `git diff --check` 通过


### PR DESCRIPTION
Adds a main-repo visible entry for the frozen EDC Java augmentation spike, linking to the tagged freeze package without merging the full Java spike into main.