### PR TITLE
docs: sync latest manuscript outcomes

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -50,6 +50,11 @@
 - 优先沿用现有 Python 包、CLI、tests、docs 结构。
 - 先交付最小闭环，再考虑更广映射。
 
+## 投稿状态同步
+- `Execution Evidence as a Verifiable Workflow Object: A Minimal Profile and Validator for Operation Accountability` — venue `The Journal of Systems & Software`；manuscript ID `JSSOFTWARE-S-26-00981`；当前状态 `rejected`；备注：已拒稿，不再作为在审稿件统计
+- `A Minimal Verifiable Profile and Validator Path for Single-Operation Accountability in FDO and Data-Space Settings` — venue `SIDS 2026 (IEEE MDM 2026 workshop)`；当前状态 `withdrawn`；备注：已撤回，不再作为在审稿件统计
+- 上述两条仅作历史状态同步，不计入当前在审稿件或 live submission 统计。
+
 ## 本轮最小验证记录
 - 命令：`./.venv/bin/ruff check agent_evidence/oap.py agent_evidence/cli/main.py demo/run_operation_accountability_demo.py tests/test_operation_accountability_profile.py`
   - 结果：`All checks passed!`

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -53,7 +53,6 @@
 ## 投稿状态同步
 - `Execution Evidence as a Verifiable Workflow Object: A Minimal Profile and Validator for Operation Accountability` — venue `The Journal of Systems & Software`；manuscript ID `JSSOFTWARE-S-26-00981`；当前状态 `rejected`；备注：已拒稿，不再作为在审稿件统计
 - `A Minimal Verifiable Profile and Validator Path for Single-Operation Accountability in FDO and Data-Space Settings` — venue `SIDS 2026 (IEEE MDM 2026 workshop)`；当前状态 `withdrawn`；备注：已撤回，不再作为在审稿件统计
-- 上述两条仅作历史状态同步，不计入当前在审稿件或 live submission 统计。
 
 ## 本轮最小验证记录
 - 命令：`./.venv/bin/ruff check agent_evidence/oap.py agent_evidence/cli/main.py demo/run_operation_accountability_demo.py tests/test_operation_accountability_profile.py`

--- a/submission/manuscript-baselines.md
+++ b/submission/manuscript-baselines.md
@@ -29,11 +29,5 @@
 
 ## Live submission status sync
 
-These manuscript baselines are not the live-submission ledger, but the current
-repository-facing submission status sync is:
-
 - `Execution Evidence as a Verifiable Workflow Object: A Minimal Profile and Validator for Operation Accountability` — venue `The Journal of Systems & Software`; manuscript ID `JSSOFTWARE-S-26-00981`; status `rejected`; note: JSS: rejected; no longer counted as an active submission
 - `A Minimal Verifiable Profile and Validator Path for Single-Operation Accountability in FDO and Data-Space Settings` — venue `SIDS 2026 (IEEE MDM 2026 workshop)`; status `withdrawn`; note: SIDS 2026: withdrawn; no longer counted as an active submission
-
-This sync does not change `B1-minimal-frozen`, `B2-extended-middle`,
-`B3-aep-live-chain`, or `B4-high-risk-current-main`.

--- a/submission/manuscript-baselines.md
+++ b/submission/manuscript-baselines.md
@@ -26,3 +26,14 @@
 - counts: `3 valid / 7 invalid`
 - claim: reviewer-facing high-risk scenario entry
 - best fit: future AI Act / high-risk / compliance-interface manuscripts
+
+## Live submission status sync
+
+These manuscript baselines are not the live-submission ledger, but the current
+repository-facing submission status sync is:
+
+- `Execution Evidence as a Verifiable Workflow Object: A Minimal Profile and Validator for Operation Accountability` — venue `The Journal of Systems & Software`; manuscript ID `JSSOFTWARE-S-26-00981`; status `rejected`; note: JSS: rejected; no longer counted as an active submission
+- `A Minimal Verifiable Profile and Validator Path for Single-Operation Accountability in FDO and Data-Space Settings` — venue `SIDS 2026 (IEEE MDM 2026 workshop)`; status `withdrawn`; note: SIDS 2026: withdrawn; no longer counted as an active submission
+
+This sync does not change `B1-minimal-frozen`, `B2-extended-middle`,
+`B3-aep-live-chain`, or `B4-high-risk-current-main`.


### PR DESCRIPTION
## Summary

This PR synchronizes the latest manuscript outcomes in two ledger-facing documents:

- `docs/STATUS.md`
- `submission/manuscript-baselines.md`

## What changed

- synced JSS status to `rejected`
- synced SIDS 2026 status to `withdrawn`

## Scope

Included:
- manuscript outcome synchronization in ledger documents

Not included:
- README changes
- code changes
- spec/schema changes
- demo/validator changes
- new manuscript surfaces
