### PR TITLE
docs: add paper ledger index for manuscript surfaces

### DIFF
--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,79 @@
+# Paper Surface
+
+This directory is the paper-facing ledger for Agent Evidence. It does not replace the canonical repository assets. It indexes manuscript surfaces, evidence traces, validation tables, and open gaps for current writing work.
+
+## Current flagship line
+
+Current working line:
+- `Execution Evidence and Operation Accountability Profile v0.1`
+
+Primary paper ledger:
+- `flagship/WORKLOG.md`
+
+This paper surface supports a minimal-verification-boundary manuscript first, then a reviewer-facing high-risk manuscript surface.
+
+## Canonical paper and project ledgers
+
+- Root research entry: `../README.md`
+- Flagship worklog: `flagship/WORKLOG.md`
+- Manuscript baselines: `../submission/manuscript-baselines.md`
+- Claims-to-evidence map: `flagship/13_claims_to_evidence_map.md`
+- Validation results table: `flagship/18_validation_results_table.md`
+- Project status and milestones: `../docs/STATUS.md`
+
+## Manuscript discipline
+
+Do not mix manuscript surfaces.
+
+- `B1-minimal-frozen`: minimal verification boundary around `Execution Evidence and Operation Accountability Profile v0.1`
+- `B4-high-risk-current-main`: reviewer-facing high-risk scenario surface
+- `B2-extended-middle`: parked unless fully rewritten
+- `B3-aep-live-chain`: historical runtime-evidence surface
+
+## Submission status pointer
+
+Live submission status remains in `../submission/manuscript-baselines.md`. Do not duplicate submission-status rows on this page.
+
+## Evidence surface
+
+Use the repository artifacts below as the concrete evidence base behind manuscript claims:
+
+- Spec: `../spec/execution-evidence-operation-accountability-profile-v0.1.md`
+- Schema: `../schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- Validator CLI and root entry: `../README.md`
+- Examples: `../examples/README.md`
+- Demo: `../demo/README.md`
+- Reviewer-facing high-risk entry: `../docs/high-risk-scenario-entry.md`
+- Submission handoff: `../submission/package-manifest.md`, `../submission/final-handoff.md`
+
+## What this paper surface currently supports
+
+- minimal verification-boundary writing
+- manuscript-to-artifact traceability
+- reviewer-facing scenario slices
+- agreement/divergence discussion around validation boundaries
+
+## Open gaps
+
+- external-context evidence
+- third-party checker
+- manuscript assembly across introduction, discussion, and conclusion
+
+## Scope discipline
+
+This page is:
+- a paper index
+- a manuscript assembly surface
+- a writing ledger
+
+This page is not:
+- a second spec
+- a project homepage
+- the live submission ledger
+- a manifesto
+
+## Near-term next work
+
+- tighten manuscript assembly
+- keep B1 and B4 surfaces separate
+- update this page only when the linked ledgers materially change


### PR DESCRIPTION
## Summary

This PR adds `paper/README.md` as the paper-facing ledger index for Agent Evidence.

## What changed

* added a single paper index page
* linked the canonical manuscript, evidence, validation, and project ledgers
* kept manuscript-surface discipline explicit
* kept live submission status delegated to `submission/manuscript-baselines.md`

## Scope

Included:

* one new documentation file: `paper/README.md`

Not included:

* README changes
* status-ledger changes
* baseline rewrites
* code/spec/schema/demo changes
* new manuscript text
