### PR TITLE
evidence: add B1 second checker surface

### DIFF
--- a/paper/flagship/second_checker/README.md
+++ b/paper/flagship/second_checker/README.md
@@ -1,0 +1,42 @@
+# Second Checker Surface
+
+This directory contains one repo-local second checker surface for the B1 line.
+
+It is not an external third-party checker.
+
+Its purpose is narrow: add one additional checker path for minimal profile inspection and
+basic closure review without changing the canonical validator implementation.
+
+It does not change B1 minimal-frozen `1 valid / 3 invalid / 1 demo`.
+
+Current files:
+
+- Checker script: `check_profile_minimal.py`
+- Canonical valid report: `reports/minimal-valid.report.json`
+- Canonical invalid report: `reports/invalid-unclosed-reference.report.json`
+- Supplementary external-context valid report: `reports/external-context-valid.report.json`
+
+Inputs used:
+
+- `examples/minimal-valid-evidence.json`
+- `examples/invalid-unclosed-reference.json`
+- `paper/flagship/external_context/data_space_metadata_update.valid.json`
+
+Run commands:
+
+```bash
+python3 paper/flagship/second_checker/check_profile_minimal.py \
+  examples/minimal-valid-evidence.json \
+  > paper/flagship/second_checker/reports/minimal-valid.report.json
+
+python3 paper/flagship/second_checker/check_profile_minimal.py \
+  examples/invalid-unclosed-reference.json \
+  > paper/flagship/second_checker/reports/invalid-unclosed-reference.report.json
+
+python3 paper/flagship/second_checker/check_profile_minimal.py \
+  paper/flagship/external_context/data_space_metadata_update.valid.json \
+  > paper/flagship/second_checker/reports/external-context-valid.report.json
+```
+
+This surface is supplementary checker evidence only. It is intended to strengthen checker
+diversity for B1 while remaining repo-local and reviewable.

--- a/paper/flagship/second_checker/check_profile_minimal.py
+++ b/paper/flagship/second_checker/check_profile_minimal.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+CHECKER_ID = "repo-local-second-checker@0.1"
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = (
+    ROOT / "schema" / "execution-evidence-operation-accountability-profile-v0.1.schema.json"
+)
+
+
+def issue(stage: str, code: str, path: str, message: str) -> dict[str, str]:
+    return {
+        "stage": stage,
+        "code": code,
+        "path": path,
+        "message": message,
+    }
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def schema_issues(profile: dict) -> list[dict[str, str]]:
+    schema = load_json(SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    issues: list[dict[str, str]] = []
+    for error in sorted(validator.iter_errors(profile), key=lambda item: list(item.path)):
+        path = ".".join(str(part) for part in error.path) or "root"
+        issues.append(issue("schema", "schema_violation", path, error.message))
+    return issues
+
+
+def minimal_closure_issues(profile: dict) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+
+    policy_id = profile.get("policy", {}).get("id")
+    evidence_policy_ref = profile.get("evidence", {}).get("policy_ref")
+    if evidence_policy_ref != policy_id:
+        issues.append(
+            issue(
+                "closure",
+                "broken_evidence_policy_ref",
+                "evidence.policy_ref",
+                "evidence.policy_ref must resolve to policy.id.",
+            )
+        )
+
+    reference_ids = {
+        reference.get("ref_id")
+        for reference in profile.get("evidence", {}).get("references", [])
+        if isinstance(reference, dict) and reference.get("ref_id")
+    }
+    for index, ref_id in enumerate(profile.get("operation", {}).get("output_refs", [])):
+        if ref_id not in reference_ids:
+            issues.append(
+                issue(
+                    "closure",
+                    "unresolved_output_ref",
+                    f"operation.output_refs[{index}]",
+                    "operation output ref does not resolve to evidence.references[].ref_id.",
+                )
+            )
+
+    return issues
+
+
+def build_report(profile_path: Path) -> dict:
+    profile = load_json(profile_path)
+    issues = schema_issues(profile)
+    if not issues:
+        issues.extend(minimal_closure_issues(profile))
+    return {
+        "checker": CHECKER_ID,
+        "ok": not issues,
+        "issue_count": len(issues),
+        "issues": issues,
+        "source": str(profile_path),
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            json.dumps(
+                {
+                    "checker": CHECKER_ID,
+                    "ok": False,
+                    "issue_count": 1,
+                    "issues": [
+                        issue(
+                            "usage",
+                            "missing_profile_path",
+                            "argv",
+                            "usage: check_profile_minimal.py <profile.json>",
+                        )
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    profile_path = Path(argv[1])
+    report = build_report(profile_path)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/paper/flagship/second_checker/reports/external-context-valid.report.json
+++ b/paper/flagship/second_checker/reports/external-context-valid.report.json
@@ -1,0 +1,7 @@
+{
+  "checker": "repo-local-second-checker@0.1",
+  "issue_count": 0,
+  "issues": [],
+  "ok": true,
+  "source": "paper/flagship/external_context/data_space_metadata_update.valid.json"
+}

--- a/paper/flagship/second_checker/reports/invalid-unclosed-reference.report.json
+++ b/paper/flagship/second_checker/reports/invalid-unclosed-reference.report.json
@@ -1,0 +1,14 @@
+{
+  "checker": "repo-local-second-checker@0.1",
+  "issue_count": 1,
+  "issues": [
+    {
+      "code": "unresolved_output_ref",
+      "message": "operation output ref does not resolve to evidence.references[].ref_id.",
+      "path": "operation.output_refs[0]",
+      "stage": "closure"
+    }
+  ],
+  "ok": false,
+  "source": "examples/invalid-unclosed-reference.json"
+}

--- a/paper/flagship/second_checker/reports/minimal-valid.report.json
+++ b/paper/flagship/second_checker/reports/minimal-valid.report.json
@@ -1,0 +1,7 @@
+{
+  "checker": "repo-local-second-checker@0.1",
+  "issue_count": 0,
+  "issues": [],
+  "ok": true,
+  "source": "examples/minimal-valid-evidence.json"
+}


### PR DESCRIPTION
## Summary

This PR adds a repo-local second checker surface for the B1 line.

## What changed

* added one standalone minimal checker script
* added three checker reports for one canonical valid case, one canonical invalid case, and one supplementary external-context valid case
* added a short README clarifying scope and limits

## Scope

Included:

* one repo-local second checker surface
* three checker reports
* one short README

Not included:

* README changes
* baseline changes
* manuscript rewrites
* canonical example-count changes
* external third-party checker claims
