### PR TITLE
evidence: add B1 third-party-checker handoff surface

### DIFF
--- a/paper/flagship/third_party_checker_handoff/README.md
+++ b/paper/flagship/third_party_checker_handoff/README.md
@@ -1,0 +1,30 @@
+# Third-Party Checker Handoff
+
+This directory is a third-party-checker handoff surface for the B1 line.
+
+Its purpose is narrow: let an external checker implementation or an external reviewer
+reuse the current canonical B1 package surface and the current supplementary surfaces
+for independent re-checking.
+
+There is still no external third-party checker result included.
+
+Canonical B1 remains:
+
+- `Execution Evidence and Operation Accountability Profile v0.1`
+- `1 valid / 3 invalid / 1 demo`
+
+Supplementary surfaces remain supplementary:
+
+- `../external_context/`
+- `../second_checker/`
+
+They support reviewer-facing inspection and future re-checking, but they do not rewrite
+canonical B1 counts.
+
+This handoff surface points to:
+
+- `checker_input_manifest.json` for canonical and supplementary inputs
+- `checker_contract.md` for the minimum expected re-checking contract
+
+This directory does not contain an external checker implementation result. It is a
+handoff surface for future independent re-checking only.

--- a/paper/flagship/third_party_checker_handoff/checker_contract.md
+++ b/paper/flagship/third_party_checker_handoff/checker_contract.md
@@ -1,0 +1,32 @@
+# Checker Contract
+
+This file defines a minimal checker contract for the third-party-checker handoff.
+
+It is a handoff contract only. There is still no external third-party checker result included.
+
+## Minimum coverage
+
+An external checker implementation should be able to cover at least:
+
+- schema validity against `schema/execution-evidence-operation-accountability-profile-v0.1.schema.json`
+- unresolved output refs
+- broken evidence-policy refs
+
+## Minimum expected outcomes
+
+The handoff expects the following minimum outcomes:
+
+- canonical valid specimen -> PASS
+- canonical invalid unclosed-reference specimen -> FAIL
+- supplementary external-context valid specimen -> PASS, if the external checker chooses to include supplementary checking
+
+## Boundary note
+
+This contract does not require a full reproduction of the current repository validator path.
+It only defines the smallest re-checking floor needed for independent review of the B1
+line.
+
+## Scope note
+
+This handoff does not change canonical B1 counts. Canonical B1 remains `1 valid / 3 invalid / 1 demo`.
+Supplementary surfaces remain supplementary.

--- a/paper/flagship/third_party_checker_handoff/checker_input_manifest.json
+++ b/paper/flagship/third_party_checker_handoff/checker_input_manifest.json
@@ -1,0 +1,52 @@
+{
+  "canonical_b1": {
+    "intended_use": "Minimum canonical inputs for independent re-checking of the B1 minimal-frozen line.",
+    "inputs": [
+      {
+        "path": "examples/minimal-valid-evidence.json",
+        "role": "canonical_valid_specimen"
+      },
+      {
+        "path": "examples/invalid-missing-required.json",
+        "role": "canonical_invalid_specimen"
+      },
+      {
+        "path": "examples/invalid-unclosed-reference.json",
+        "role": "canonical_invalid_specimen"
+      },
+      {
+        "path": "examples/invalid-policy-link-broken.json",
+        "role": "canonical_invalid_specimen"
+      },
+      {
+        "path": "spec/execution-evidence-operation-accountability-profile-v0.1.md",
+        "role": "canonical_profile_spec"
+      },
+      {
+        "path": "schema/execution-evidence-operation-accountability-profile-v0.1.schema.json",
+        "role": "canonical_profile_schema"
+      }
+    ]
+  },
+  "supplementary": {
+    "intended_use": "Optional supplementary inputs for boundary-stability and checker-diversity re-checking. These remain supplementary and do not change canonical B1 counts.",
+    "inputs": [
+      {
+        "path": "paper/flagship/external_context/data_space_metadata_update.valid.json",
+        "role": "supplementary_external_context_specimen"
+      },
+      {
+        "path": "paper/flagship/second_checker/reports/minimal-valid.report.json",
+        "role": "supplementary_second_checker_report"
+      },
+      {
+        "path": "paper/flagship/second_checker/reports/invalid-unclosed-reference.report.json",
+        "role": "supplementary_second_checker_report"
+      },
+      {
+        "path": "paper/flagship/second_checker/reports/external-context-valid.report.json",
+        "role": "supplementary_second_checker_report"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a minimal handoff surface for future independent re-checking of the B1 line.

## What changed

* added a reviewer-facing README
* added an input manifest for canonical and supplementary checking inputs
* added a minimal checker contract for future external implementations

## Scope

Included:

* one handoff surface for future external checker work

Not included:

* actual external third-party checker results
* README changes
* baseline changes
* manuscript rewrites
* canonical B1 count changes
