### PR TITLE
feat: add AGT-to-EEOAP interoperability adapter

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -14,6 +14,7 @@
 - M3 样例集：已完成
 - M4 validator 与 CLI：已完成
 - M5 demo 与文稿：已完成
+- M12 AGT-to-EEOAP v0.1 reference adapter：已完成
 - M7 旗舰论文规划包：已完成
 - M8 frozen EDC Java spike main-repo entry：已完成
 
@@ -49,6 +50,46 @@
 - 不平行新建第二套工程。
 - 优先沿用现有 Python 包、CLI、tests、docs 结构。
 - 先交付最小闭环，再考虑更广映射。
+
+## M12 AGT-to-EEOAP v0.1 reference adapter
+- 状态：已完成
+- 定位结论：
+  - 本轮只做 `AGT-to-EEOAP Interoperability Adapter`，作为一个外部、非侵入式 reference integration。
+  - AGT 被定位为 upstream runtime governance source；EEOAP v0.1 保持为 external operation-accountability statement format。
+  - 本轮不修改 EEOAP v0.1 schema，不修改现有 validator 语义，不引入 AGT package dependency。
+- 本轮新增产物：
+  - `docs/cookbooks/agt_to_eeoap_v0_1.md`
+  - `integrations/agt/README.md`
+  - `integrations/agt/convert_agt_evidence_to_eeoap.py`
+  - `integrations/agt/fixtures/agt-evidence-minimal.synthetic.json`
+  - `integrations/agt/fixtures/eeoap-from-agt.expected.json`
+  - `tests/test_agt_adapter.py`
+- 本轮边界收敛：
+  - `agt-evidence-minimal.synthetic.json` 明确为 synthetic AGT-like runtime evidence，不声明为 AGT 官方 schema。
+  - 转换器复用 `agent_evidence.oap.sha256_digest` 与 `with_recomputed_integrity` 计算 `references_digest`、`artifacts_digest`、`statement_digest`。
+  - 转换结果只使用 EEOAP v0.1 schema 允许的顶层字段。
+  - AGT runtime evidence 和 decision receipt 均进入 `evidence.artifacts[]`，不新增 `agt_*` 顶层字段。
+- 验收结果：
+  - synthetic AGT-like fixture 能转换为合法 EEOAP v0.1 statement。
+  - 转换结果通过 `agent-evidence validate-profile` / `validate_profile_file`。
+  - AGT-specific material 只作为 `evidence.artifacts[]` 引用，不进入顶层字段。
+  - 现有 profile schema 和 validator 语义保持不变。
+- 本轮核验：
+  - 命令：`python3 integrations/agt/convert_agt_evidence_to_eeoap.py --input integrations/agt/fixtures/agt-evidence-minimal.synthetic.json --output integrations/agt/fixtures/eeoap-from-agt.generated.json`
+    - 结果：生成 `integrations/agt/fixtures/eeoap-from-agt.generated.json`
+    - 是否通过：通过
+  - 命令：`agent-evidence validate-profile integrations/agt/fixtures/eeoap-from-agt.generated.json`
+    - 结果：`ok: true`, `issue_count: 0`
+    - 是否通过：通过
+  - 命令：`python -m pytest tests/test_agt_adapter.py`
+    - 结果：`1 passed`
+    - 是否通过：通过
+  - 命令：`ruff check integrations/agt/convert_agt_evidence_to_eeoap.py tests/test_agt_adapter.py`
+    - 结果：`All checks passed!`
+    - 是否通过：通过
+  - 命令：`python -m pytest`
+    - 结果：`67 passed, 1 skipped, 15 warnings`
+    - 是否通过：通过；warnings 为既有 Python 3.14 / langchain 兼容性提示
 
 ## 投稿状态同步
 - `Execution Evidence as a Verifiable Workflow Object: A Minimal Profile and Validator for Operation Accountability` — venue `The Journal of Systems & Software`；manuscript ID `JSSOFTWARE-S-26-00981`；当前状态 `rejected`；备注：已拒稿，不再作为在审稿件统计

--- a/docs/cookbooks/agt_to_eeoap_v0_1.md
+++ b/docs/cookbooks/agt_to_eeoap_v0_1.md
@@ -1,0 +1,55 @@
+# Mapping AGT runtime evidence to EEOAP v0.1
+
+This note defines a minimal, non-invasive interoperability path from
+Microsoft Agent Governance Toolkit runtime evidence into the Execution Evidence
+and Operation Accountability Profile v0.1.
+
+## Scope
+
+This mapping does not modify AGT runtime governance, policy enforcement,
+identity, or sandboxing behavior.
+
+It treats AGT as an upstream runtime governance source and EEOAP v0.1 as an
+external operation-accountability statement format.
+
+## Pipeline
+
+```text
+AGT runtime event / evidence
+-> AGT-to-EEOAP adapter
+-> EEOAP v0.1 statement
+-> agent-evidence validate-profile
+-> offline validation result
+```
+
+## Non-goals
+
+- No AGT runtime changes
+- No AGT policy-engine changes
+- No new EEOAP v0.1 fields
+- No dependency on AGT internals
+- No replacement of `agt verify --evidence`
+
+## Mapping
+
+| AGT concept | EEOAP v0.1 field |
+|---|---|
+| Agent identity | `actor` |
+| Governed action/tool call | `operation` |
+| Governed resource/object | `subject` |
+| Policy decision | `policy` / `constraints` |
+| Runtime audit material | `evidence.artifacts` |
+| Input/output material | `evidence.references` |
+| Runtime linkage | `provenance` |
+| Independent profile validation | `validation` |
+
+## Boundary
+
+AGT verifies governance evidence within its own runtime-governance model.
+
+EEOAP v0.1 verifies whether a single operation-accountability statement is
+structurally complete, internally consistent, and independently checkable.
+
+The adapter keeps AGT-specific material out of the EEOAP top level. Runtime
+receipts, policy decisions, and synthetic source evidence are represented as
+`evidence.artifacts[]` entries or artifact locators.

--- a/integrations/agt/README.md
+++ b/integrations/agt/README.md
@@ -1,0 +1,62 @@
+# AGT-to-EEOAP Interoperability Adapter
+
+This integration is a reference interoperability adapter, not an AGT plugin and
+not a replacement for AGT runtime evidence verification.
+
+This directory contains a minimal reference adapter that maps a synthetic
+AGT-like runtime evidence fixture into the Execution Evidence and Operation
+Accountability Profile v0.1.
+
+The fixture is synthetic. It is not an official Microsoft Agent Governance
+Toolkit schema and should not be treated as one. The purpose is to demonstrate a
+stable interoperability boundary:
+
+```text
+AGT-like runtime evidence
+-> EEOAP v0.1 statement
+-> agent-evidence validate-profile
+-> PASS / FAIL result
+```
+
+AGT remains the upstream runtime governance source. EEOAP v0.1 remains the
+external operation-accountability profile. This adapter does not replace
+`agt verify --evidence`.
+
+## Usage
+
+Run the converter:
+
+```bash
+python integrations/agt/convert_agt_evidence_to_eeoap.py \
+  --input integrations/agt/fixtures/agt-evidence-minimal.synthetic.json \
+  --output integrations/agt/fixtures/eeoap-from-agt.generated.json
+```
+
+Validate the generated statement:
+
+```bash
+agent-evidence validate-profile integrations/agt/fixtures/eeoap-from-agt.generated.json
+```
+
+You can also compare the generated output with the deterministic expected
+fixture:
+
+```bash
+diff -u \
+  integrations/agt/fixtures/eeoap-from-agt.expected.json \
+  integrations/agt/fixtures/eeoap-from-agt.generated.json
+```
+
+## Mapping Boundary
+
+The EEOAP statement does not add AGT-specific top-level fields. Synthetic AGT
+runtime material is represented through `evidence.artifacts[]`, including a
+digest of the source fixture and the AGT-like decision receipt artifact.
+
+Non-goals:
+
+- No AGT runtime modification
+- No AGT policy engine modification
+- No new EEOAP v0.1 fields
+- No AGT package dependency
+- No replacement of `agt verify --evidence`

--- a/integrations/agt/convert_agt_evidence_to_eeoap.py
+++ b/integrations/agt/convert_agt_evidence_to_eeoap.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agent_evidence.oap import sha256_digest, with_recomputed_integrity  # noqa: E402
+
+
+class ConversionError(ValueError):
+    """Raised when the synthetic AGT-like fixture cannot be mapped."""
+
+
+def _required_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ConversionError(f"expected object at {key}")
+    return value
+
+
+def _required_string(payload: dict[str, Any], path: str) -> str:
+    current: Any = payload
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise ConversionError(f"missing required field: {path}")
+        current = current[part]
+    if not isinstance(current, str) or not current:
+        raise ConversionError(f"expected non-empty string at {path}")
+    return current
+
+
+def _constraints(policy_decision: dict[str, Any]) -> list[dict[str, str]]:
+    raw_constraints = policy_decision.get("constraints")
+    if not isinstance(raw_constraints, list) or not raw_constraints:
+        raise ConversionError("expected non-empty array at policy_decision.constraints")
+
+    constraints: list[dict[str, str]] = []
+    for index, raw_constraint in enumerate(raw_constraints):
+        if not isinstance(raw_constraint, dict):
+            raise ConversionError(f"expected object at policy_decision.constraints[{index}]")
+        constraint_id = _required_string(raw_constraint, "id")
+        description = _required_string(raw_constraint, "description")
+        constraints.append({"id": constraint_id, "description": description})
+    return constraints
+
+
+def _operation_status(policy_result: str) -> str:
+    return "succeeded" if policy_result == "allow" else "failed"
+
+
+def convert_agt_evidence_to_eeoap(agt_evidence: dict[str, Any]) -> dict[str, Any]:
+    """Convert the synthetic AGT-like fixture into an EEOAP v0.1 statement."""
+
+    agent = _required_mapping(agt_evidence, "agent")
+    action = _required_mapping(agt_evidence, "action")
+    subject = _required_mapping(agt_evidence, "subject")
+    policy_decision = _required_mapping(agt_evidence, "policy_decision")
+    input_ref = _required_mapping(agt_evidence, "input")
+    output_ref = _required_mapping(agt_evidence, "output")
+    audit_artifact = _required_mapping(agt_evidence, "audit_artifact")
+    constraints = _constraints(policy_decision)
+
+    action_id = _required_string(action, "id")
+    action_name = _required_string(action, "name")
+    action_type = _required_string(action, "type")
+    operation_id = f"op:{action_id}"
+    provenance_id = f"prov:{action_id}"
+    evidence_id = f"evidence:{action_id}"
+    policy_result = _required_string(policy_decision, "result")
+
+    statement = {
+        "profile": {
+            "name": "execution-evidence-operation-accountability-profile",
+            "version": "0.1",
+        },
+        "statement_id": f"eeoap:{action_id}",
+        "timestamp": _required_string(agt_evidence, "timestamp"),
+        "actor": {
+            "id": _required_string(agent, "id"),
+            "type": "agent",
+            "name": _required_string(agent, "name"),
+            "runtime": _required_string(agent, "runtime"),
+        },
+        "subject": {
+            "id": _required_string(subject, "id"),
+            "type": _required_string(subject, "type"),
+            "digest": _required_string(subject, "digest"),
+            "locator": _required_string(subject, "locator"),
+        },
+        "operation": {
+            "id": operation_id,
+            "type": action_name,
+            "description": f"Mapped from AGT action {action_id} ({action_type}).",
+            "subject_ref": _required_string(subject, "id"),
+            "policy_ref": _required_string(policy_decision, "id"),
+            "input_refs": ["ref:agt-input"],
+            "output_refs": ["ref:agt-output"],
+            "result": {
+                "status": _operation_status(policy_result),
+                "summary": f"AGT policy decision {policy_result} for {action_name}.",
+            },
+        },
+        "policy": {
+            "id": _required_string(policy_decision, "id"),
+            "name": _required_string(policy_decision, "name"),
+            "constraint_refs": [constraint["id"] for constraint in constraints],
+        },
+        "constraints": constraints,
+        "provenance": {
+            "id": provenance_id,
+            "actor_ref": _required_string(agent, "id"),
+            "operation_ref": operation_id,
+            "subject_ref": _required_string(subject, "id"),
+            "input_refs": ["ref:agt-input"],
+            "output_refs": ["ref:agt-output"],
+        },
+        "evidence": {
+            "id": evidence_id,
+            "subject_ref": _required_string(subject, "id"),
+            "operation_ref": operation_id,
+            "policy_ref": _required_string(policy_decision, "id"),
+            "references": [
+                {
+                    "ref_id": "ref:agt-input",
+                    "role": "input",
+                    "object_id": _required_string(input_ref, "id"),
+                    "digest": _required_string(input_ref, "digest"),
+                    "locator": _required_string(input_ref, "locator"),
+                },
+                {
+                    "ref_id": "ref:agt-output",
+                    "role": "output",
+                    "object_id": _required_string(output_ref, "id"),
+                    "digest": _required_string(output_ref, "digest"),
+                    "locator": _required_string(output_ref, "locator"),
+                },
+            ],
+            "artifacts": [
+                {
+                    "artifact_id": "artifact:agt-runtime-evidence-001",
+                    "type": _required_string(agt_evidence, "source"),
+                    "digest": sha256_digest(agt_evidence),
+                    "locator": _required_string(agt_evidence, "source_locator"),
+                },
+                {
+                    "artifact_id": _required_string(audit_artifact, "id"),
+                    "type": _required_string(audit_artifact, "type"),
+                    "digest": _required_string(audit_artifact, "digest"),
+                    "locator": _required_string(audit_artifact, "locator"),
+                },
+            ],
+            "integrity": {},
+        },
+        "validation": {
+            "id": f"validation:{action_id}",
+            "evidence_ref": evidence_id,
+            "provenance_ref": provenance_id,
+            "policy_ref": _required_string(policy_decision, "id"),
+            "validator": "agent-evidence validate-profile",
+            "method": "schema+reference+consistency",
+            "status": "verifiable",
+        },
+    }
+    return with_recomputed_integrity(statement)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ConversionError(f"expected JSON object: {path}")
+    return payload
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert synthetic AGT-like evidence into an EEOAP v0.1 statement."
+    )
+    parser.add_argument("--input", required=True, type=Path, help="Synthetic AGT-like JSON input.")
+    parser.add_argument("--output", required=True, type=Path, help="EEOAP v0.1 JSON output.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        agt_evidence = load_json(args.input)
+        statement = convert_agt_evidence_to_eeoap(agt_evidence)
+        write_json(args.output, statement)
+    except (ConversionError, json.JSONDecodeError, OSError) as exc:
+        print(f"AGT-to-EEOAP conversion failed: {exc}", file=sys.stderr)
+        return 1
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/agt/fixtures/agt-evidence-minimal.synthetic.json
+++ b/integrations/agt/fixtures/agt-evidence-minimal.synthetic.json
@@ -1,0 +1,48 @@
+{
+  "source": "synthetic-agt-runtime-evidence",
+  "source_locator": "urn:demo:agt-evidence-minimal.synthetic",
+  "agent": {
+    "id": "did:agentmesh:demo-agent",
+    "name": "demo-agent",
+    "runtime": "agent-governance-toolkit"
+  },
+  "action": {
+    "id": "agt-action-001",
+    "type": "tool.call",
+    "name": "metadata.enrich"
+  },
+  "subject": {
+    "id": "obj:client-note-001",
+    "type": "fdo-record",
+    "locator": "urn:demo:client-note-001",
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "policy_decision": {
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy",
+    "constraints": [
+      {
+        "id": "constraint:approved-fields",
+        "description": "Only approved metadata fields may be added."
+      }
+    ],
+    "result": "allow"
+  },
+  "input": {
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "output": {
+    "id": "obj:client-note-001-derived",
+    "locator": "urn:demo:client-note-001-derived",
+    "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "audit_artifact": {
+    "id": "artifact:agt-decision-receipt-001",
+    "type": "agt-decision-receipt",
+    "locator": "urn:demo:agt-decision-receipt-001",
+    "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "timestamp": "2026-04-22T00:00:00Z"
+}

--- a/integrations/agt/fixtures/eeoap-from-agt.expected.json
+++ b/integrations/agt/fixtures/eeoap-from-agt.expected.json
@@ -1,0 +1,112 @@
+{
+  "actor": {
+    "id": "did:agentmesh:demo-agent",
+    "name": "demo-agent",
+    "runtime": "agent-governance-toolkit",
+    "type": "agent"
+  },
+  "constraints": [
+    {
+      "description": "Only approved metadata fields may be added.",
+      "id": "constraint:approved-fields"
+    }
+  ],
+  "evidence": {
+    "artifacts": [
+      {
+        "artifact_id": "artifact:agt-runtime-evidence-001",
+        "digest": "sha256:18cc5476d2a2ab85a3e58483210452e40086e59a2c87577a8eeec64092d86758",
+        "locator": "urn:demo:agt-evidence-minimal.synthetic",
+        "type": "synthetic-agt-runtime-evidence"
+      },
+      {
+        "artifact_id": "artifact:agt-decision-receipt-001",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": "urn:demo:agt-decision-receipt-001",
+        "type": "agt-decision-receipt"
+      }
+    ],
+    "id": "evidence:agt-action-001",
+    "integrity": {
+      "artifacts_digest": "sha256:8cb6ad0242c9116ec8b5b870c832235ed14395d956e93f8727cdc9e48f7997af",
+      "references_digest": "sha256:669dbfdba60bdf12a07f1a288e294d8675aa7982867efe1c879dbffb5b50077e",
+      "statement_digest": "sha256:3b6b1e5254969356fe81ee727410681f5918460ef7cfa997c125aaa65fd5e7da"
+    },
+    "operation_ref": "op:agt-action-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "references": [
+      {
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": "urn:demo:client-note-001",
+        "object_id": "obj:client-note-001",
+        "ref_id": "ref:agt-input",
+        "role": "input"
+      },
+      {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": "urn:demo:client-note-001-derived",
+        "object_id": "obj:client-note-001-derived",
+        "ref_id": "ref:agt-output",
+        "role": "output"
+      }
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "operation": {
+    "description": "Mapped from AGT action agt-action-001 (tool.call).",
+    "id": "op:agt-action-001",
+    "input_refs": [
+      "ref:agt-input"
+    ],
+    "output_refs": [
+      "ref:agt-output"
+    ],
+    "policy_ref": "policy:approved-metadata-v1",
+    "result": {
+      "status": "succeeded",
+      "summary": "AGT policy decision allow for metadata.enrich."
+    },
+    "subject_ref": "obj:client-note-001",
+    "type": "metadata.enrich"
+  },
+  "policy": {
+    "constraint_refs": [
+      "constraint:approved-fields"
+    ],
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy"
+  },
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "provenance": {
+    "actor_ref": "did:agentmesh:demo-agent",
+    "id": "prov:agt-action-001",
+    "input_refs": [
+      "ref:agt-input"
+    ],
+    "operation_ref": "op:agt-action-001",
+    "output_refs": [
+      "ref:agt-output"
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "statement_id": "eeoap:agt-action-001",
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "type": "fdo-record"
+  },
+  "timestamp": "2026-04-22T00:00:00Z",
+  "validation": {
+    "evidence_ref": "evidence:agt-action-001",
+    "id": "validation:agt-action-001",
+    "method": "schema+reference+consistency",
+    "policy_ref": "policy:approved-metadata-v1",
+    "provenance_ref": "prov:agt-action-001",
+    "status": "verifiable",
+    "validator": "agent-evidence validate-profile"
+  }
+}

--- a/integrations/agt/fixtures/eeoap-from-agt.generated.json
+++ b/integrations/agt/fixtures/eeoap-from-agt.generated.json
@@ -1,0 +1,112 @@
+{
+  "actor": {
+    "id": "did:agentmesh:demo-agent",
+    "name": "demo-agent",
+    "runtime": "agent-governance-toolkit",
+    "type": "agent"
+  },
+  "constraints": [
+    {
+      "description": "Only approved metadata fields may be added.",
+      "id": "constraint:approved-fields"
+    }
+  ],
+  "evidence": {
+    "artifacts": [
+      {
+        "artifact_id": "artifact:agt-runtime-evidence-001",
+        "digest": "sha256:18cc5476d2a2ab85a3e58483210452e40086e59a2c87577a8eeec64092d86758",
+        "locator": "urn:demo:agt-evidence-minimal.synthetic",
+        "type": "synthetic-agt-runtime-evidence"
+      },
+      {
+        "artifact_id": "artifact:agt-decision-receipt-001",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": "urn:demo:agt-decision-receipt-001",
+        "type": "agt-decision-receipt"
+      }
+    ],
+    "id": "evidence:agt-action-001",
+    "integrity": {
+      "artifacts_digest": "sha256:8cb6ad0242c9116ec8b5b870c832235ed14395d956e93f8727cdc9e48f7997af",
+      "references_digest": "sha256:669dbfdba60bdf12a07f1a288e294d8675aa7982867efe1c879dbffb5b50077e",
+      "statement_digest": "sha256:3b6b1e5254969356fe81ee727410681f5918460ef7cfa997c125aaa65fd5e7da"
+    },
+    "operation_ref": "op:agt-action-001",
+    "policy_ref": "policy:approved-metadata-v1",
+    "references": [
+      {
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": "urn:demo:client-note-001",
+        "object_id": "obj:client-note-001",
+        "ref_id": "ref:agt-input",
+        "role": "input"
+      },
+      {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": "urn:demo:client-note-001-derived",
+        "object_id": "obj:client-note-001-derived",
+        "ref_id": "ref:agt-output",
+        "role": "output"
+      }
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "operation": {
+    "description": "Mapped from AGT action agt-action-001 (tool.call).",
+    "id": "op:agt-action-001",
+    "input_refs": [
+      "ref:agt-input"
+    ],
+    "output_refs": [
+      "ref:agt-output"
+    ],
+    "policy_ref": "policy:approved-metadata-v1",
+    "result": {
+      "status": "succeeded",
+      "summary": "AGT policy decision allow for metadata.enrich."
+    },
+    "subject_ref": "obj:client-note-001",
+    "type": "metadata.enrich"
+  },
+  "policy": {
+    "constraint_refs": [
+      "constraint:approved-fields"
+    ],
+    "id": "policy:approved-metadata-v1",
+    "name": "approved-metadata-policy"
+  },
+  "profile": {
+    "name": "execution-evidence-operation-accountability-profile",
+    "version": "0.1"
+  },
+  "provenance": {
+    "actor_ref": "did:agentmesh:demo-agent",
+    "id": "prov:agt-action-001",
+    "input_refs": [
+      "ref:agt-input"
+    ],
+    "operation_ref": "op:agt-action-001",
+    "output_refs": [
+      "ref:agt-output"
+    ],
+    "subject_ref": "obj:client-note-001"
+  },
+  "statement_id": "eeoap:agt-action-001",
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "id": "obj:client-note-001",
+    "locator": "urn:demo:client-note-001",
+    "type": "fdo-record"
+  },
+  "timestamp": "2026-04-22T00:00:00Z",
+  "validation": {
+    "evidence_ref": "evidence:agt-action-001",
+    "id": "validation:agt-action-001",
+    "method": "schema+reference+consistency",
+    "policy_ref": "policy:approved-metadata-v1",
+    "provenance_ref": "prov:agt-action-001",
+    "status": "verifiable",
+    "validator": "agent-evidence validate-profile"
+  }
+}

--- a/plans/implementation-plan.md
+++ b/plans/implementation-plan.md
@@ -73,3 +73,23 @@
   - 明确说明当前应引用 freeze package，而不是把整条 Java spike 直接并入 `main`
   - 不复制 `spikes/edc-java-extension/`，不合并 Java 代码，不新增运行时功能
   - `git diff --check` 通过
+
+## M12 AGT-to-EEOAP v0.1 reference adapter
+- 输入：
+  - 当前 canonical package：`Execution Evidence and Operation Accountability Profile v0.1`
+  - 现有 `agent_evidence/oap.py` digest / validation helpers
+  - 现有 `schema/`、`integrations/`、`docs/cookbooks/`、`tests/` 结构
+  - 一个明确标注为 synthetic 的 AGT-like runtime evidence fixture
+- 输出：
+  - `docs/cookbooks/agt_to_eeoap_v0_1.md`
+  - `integrations/agt/README.md`
+  - `integrations/agt/convert_agt_evidence_to_eeoap.py`
+  - `integrations/agt/fixtures/agt-evidence-minimal.synthetic.json`
+  - `integrations/agt/fixtures/eeoap-from-agt.expected.json`
+  - `tests/test_agt_adapter.py`
+- 验收条件：
+  - 转换器读取 synthetic AGT-like evidence，并输出合法 EEOAP v0.1 statement
+  - 输出 statement 通过现有 `validate_profile_file` 和 CLI `agent-evidence validate-profile`
+  - AGT-specific runtime material 被保留为 `evidence.artifacts[]` 中的 artifact 引用，不新增顶层字段
+  - 不修改 EEOAP v0.1 schema、不修改 validator 语义、不引入 AGT package dependency
+  - 文档明确 non-goals：不改 AGT runtime、不改 AGT policy engine、不新增 EEOAP 字段、不替代 `agt verify --evidence`

--- a/tests/test_agt_adapter.py
+++ b/tests/test_agt_adapter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from agent_evidence.oap import validate_profile_file
+
+ROOT = Path(__file__).resolve().parents[1]
+AGT_DIR = ROOT / "integrations" / "agt"
+CONVERTER = AGT_DIR / "convert_agt_evidence_to_eeoap.py"
+FIXTURE = AGT_DIR / "fixtures" / "agt-evidence-minimal.synthetic.json"
+EXPECTED = AGT_DIR / "fixtures" / "eeoap-from-agt.expected.json"
+
+
+def test_agt_adapter_generates_valid_eeoap_statement(tmp_path: Path) -> None:
+    output = tmp_path / "eeoap-from-agt.generated.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(CONVERTER),
+            "--input",
+            str(FIXTURE),
+            "--output",
+            str(output),
+        ],
+        check=True,
+        cwd=ROOT,
+    )
+
+    generated = json.loads(output.read_text(encoding="utf-8"))
+    expected = json.loads(EXPECTED.read_text(encoding="utf-8"))
+    assert generated == expected
+
+    report = validate_profile_file(output)
+    assert report["ok"] is True
+    assert report["issue_count"] == 0
+
+    expected_top_level = {
+        "profile",
+        "statement_id",
+        "timestamp",
+        "actor",
+        "subject",
+        "operation",
+        "policy",
+        "constraints",
+        "provenance",
+        "evidence",
+        "validation",
+    }
+    assert set(generated) == expected_top_level
+    assert not {"agent", "action", "policy_decision", "audit_artifact"} & set(generated)
+    assert all(not key.startswith("agt_") for key in generated)
+
+    artifact_ids = {artifact["artifact_id"] for artifact in generated["evidence"]["artifacts"]}
+    assert "artifact:agt-runtime-evidence-001" in artifact_ids
+    assert "artifact:agt-decision-receipt-001" in artifact_ids


### PR DESCRIPTION
## Summary

This PR adds a minimal, non-invasive AGT-to-EEOAP interoperability adapter.

It maps a synthetic AGT-like runtime evidence fixture into an EEOAP v0.1 operation-accountability statement and validates the generated output using the existing profile validator.

## Scope

This PR does not change:

- EEOAP v0.1 schema
- validator semantics
- CLI behavior
- package metadata

It adds:

- AGT mapping cookbook
- AGT integration README
- synthetic AGT-like evidence fixture
- converter from AGT-like evidence to EEOAP v0.1
- expected/generated EEOAP fixture
- adapter regression test

## Why

AGT-style runtime governance evidence can be treated as an upstream source for an external operation-accountability profile.

The adapter keeps AGT-specific material as evidence artifacts rather than adding AGT-specific top-level fields to the EEOAP statement.

## Validation

- `agent-evidence validate-profile integrations/agt/fixtures/eeoap-from-agt.generated.json` -> `ok: true`
- `python -m pytest tests/test_agt_adapter.py` -> `1 passed`
- `ruff check integrations/agt/convert_agt_evidence_to_eeoap.py tests/test_agt_adapter.py` -> passed
- `python -m pytest` -> `67 passed, 1 skipped`

## Notes

The AGT fixture is synthetic and is not presented as an official AGT evidence schema.