### PR TITLE
Fix deterministic canonicalization for unordered evidence payloads

### DIFF
--- a/agent_evidence/_canonical.py
+++ b/agent_evidence/_canonical.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+def _sort_key(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=True,
+    )
+
+
+def canonicalize_unordered_collection(
+    values: Iterable[Any],
+    *,
+    normalize_item: Callable[[Any], Any],
+    limit: int | None = None,
+) -> list[Any]:
+    normalized_items = [normalize_item(item) for item in values]
+    normalized_items.sort(key=_sort_key)
+    if limit is not None:
+        return normalized_items[:limit]
+    return normalized_items

--- a/agent_evidence/aep/canonicalizer.py
+++ b/agent_evidence/aep/canonicalizer.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any, Mapping
 from uuid import UUID
 
+from agent_evidence._canonical import canonicalize_unordered_collection
+
 
 def canonicalize(value: Any) -> Any:
     """Normalize Python values into a deterministic JSON-compatible shape."""
@@ -17,8 +19,10 @@ def canonicalize(value: Any) -> Any:
             str(key): canonicalize(item)
             for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
         }
-    if isinstance(value, (list, tuple, set, frozenset)):
+    if isinstance(value, (list, tuple)):
         return [canonicalize(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return canonicalize_unordered_collection(value, normalize_item=canonicalize)
     if isinstance(value, (datetime, date, time)):
         return value.isoformat()
     if isinstance(value, UUID):

--- a/agent_evidence/serialization.py
+++ b/agent_evidence/serialization.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 from uuid import UUID
 
+from agent_evidence._canonical import canonicalize_unordered_collection
+
 DEFAULT_REDACT_KEYS = {
     "api_key",
     "authorization",
@@ -115,9 +117,11 @@ def _to_jsonable(value: Any, depth: int, seen: set[int]) -> Any:
                 _to_jsonable(item, depth + 1, seen) for item in list(value)[:MAX_COLLECTION_SIZE]
             ]
         if isinstance(value, set | frozenset):
-            return [
-                _to_jsonable(item, depth + 1, seen) for item in list(value)[:MAX_COLLECTION_SIZE]
-            ]
+            return canonicalize_unordered_collection(
+                value,
+                normalize_item=lambda item: _to_jsonable(item, depth + 1, seen),
+                limit=MAX_COLLECTION_SIZE,
+            )
         return _truncate_string(repr(value))
     finally:
         seen.remove(object_id)

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -2,8 +2,10 @@ import math
 
 import pytest
 
+from agent_evidence.aep.canonicalizer import canonical_json_bytes as aep_canonical_json_bytes
 from agent_evidence.crypto.chain import chain_digest_for_event
 from agent_evidence.crypto.hashing import canonical_json_bytes, compute_hash
+from agent_evidence.serialization import to_jsonable
 
 
 def test_canonical_json_is_stable() -> None:
@@ -22,3 +24,38 @@ def test_chain_digest_changes_with_previous_link() -> None:
 def test_canonical_json_rejects_non_finite_floats() -> None:
     with pytest.raises(ValueError):
         canonical_json_bytes({"value": math.nan})
+
+
+def test_aep_canonical_json_sorts_unordered_collections() -> None:
+    payload = {
+        "tags": {"beta", "alpha"},
+        "nested": frozenset({("team", "ops"), ("team", "ml")}),
+    }
+
+    expected = b'{"nested":[["team","ml"],["team","ops"]],"tags":["alpha","beta"]}'
+
+    assert aep_canonical_json_bytes(payload) == expected
+
+
+def test_hash_is_stable_for_jsonable_payloads_with_sets() -> None:
+    left = {
+        "tags": {"beta", "alpha"},
+        "nested": frozenset({("team", "ops"), ("team", "ml")}),
+    }
+    right = {
+        "tags": {"alpha", "beta"},
+        "nested": frozenset({("team", "ml"), ("team", "ops")}),
+    }
+
+    assert compute_hash(to_jsonable(left)) == compute_hash(to_jsonable(right))
+
+
+def test_unordered_collection_with_mixed_jsonable_types_is_stable() -> None:
+    left = {"values": {1, "1", None}}
+    right = {"values": {None, "1", 1}}
+
+    left_aep = aep_canonical_json_bytes(left)
+    right_aep = aep_canonical_json_bytes(right)
+
+    assert left_aep == right_aep
+    assert compute_hash(to_jsonable(left)) == compute_hash(to_jsonable(right))

--- a/tests/test_serialization_security.py
+++ b/tests/test_serialization_security.py
@@ -60,3 +60,15 @@ def test_to_jsonable_limits_collection_sizes() -> None:
 
     assert len(serialized["items"]) == MAX_COLLECTION_SIZE
     assert len(serialized["mapping"]) == MAX_COLLECTION_SIZE
+
+
+def test_to_jsonable_sorts_unordered_collections_deterministically() -> None:
+    payload = {
+        "tags": {"beta", "alpha"},
+        "nested": frozenset({("team", "ops"), ("team", "ml")}),
+    }
+
+    serialized = to_jsonable(payload)
+
+    assert serialized["tags"] == ["alpha", "beta"]
+    assert serialized["nested"] == [["team", "ml"], ["team", "ops"]]


### PR DESCRIPTION
This PR completes the first evidence integrity hardening step.

Changes:
- Adds shared canonical handling for unordered collections.
- Makes set / frozenset serialization deterministic in AEP canonicalization.
- Makes runtime evidence serialization deterministic for unordered evidence payloads.
- Adds regression tests for ordinary and mixed-type unordered collections.

Validation:
- ruff check: passed
- ruff format --check: passed
- pytest: passed

Compatibility:
- Public schema is unchanged.
- README narrative is unchanged.
- Previously generated hashes for payloads containing set / frozenset may differ from earlier non-deterministic outputs. This is an expected correction.