### PR TITLE
Guard oversized unordered canonical collections

### DIFF
--- a/agent_evidence/_canonical.py
+++ b/agent_evidence/_canonical.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Collection
 from typing import Any
 
 
@@ -16,13 +16,14 @@ def _sort_key(value: Any) -> str:
 
 
 def canonicalize_unordered_collection(
-    values: Iterable[Any],
+    values: Collection[Any],
     *,
     normalize_item: Callable[[Any], Any],
     limit: int | None = None,
 ) -> list[Any]:
+    if limit is not None and len(values) > limit:
+        raise ValueError(f"unordered collection exceeds maximum size: {len(values)} > {limit}")
+
     normalized_items = [normalize_item(item) for item in values]
     normalized_items.sort(key=_sort_key)
-    if limit is not None:
-        return normalized_items[:limit]
     return normalized_items

--- a/tests/test_serialization_security.py
+++ b/tests/test_serialization_security.py
@@ -1,3 +1,6 @@
+import pytest
+
+from agent_evidence._canonical import canonicalize_unordered_collection
 from agent_evidence.serialization import (
     MAX_COLLECTION_SIZE,
     MAX_STRING_LENGTH,
@@ -54,12 +57,16 @@ def test_to_jsonable_limits_collection_sizes() -> None:
     payload = {
         "items": list(range(MAX_COLLECTION_SIZE + 50)),
         "mapping": {f"k{i}": i for i in range(MAX_COLLECTION_SIZE + 50)},
+        "tuple_items": tuple(range(MAX_COLLECTION_SIZE + 50)),
     }
 
     serialized = to_jsonable(payload)
 
     assert len(serialized["items"]) == MAX_COLLECTION_SIZE
     assert len(serialized["mapping"]) == MAX_COLLECTION_SIZE
+    assert len(serialized["tuple_items"]) == MAX_COLLECTION_SIZE
+    assert serialized["items"] == list(range(MAX_COLLECTION_SIZE))
+    assert serialized["tuple_items"] == list(range(MAX_COLLECTION_SIZE))
 
 
 def test_to_jsonable_sorts_unordered_collections_deterministically() -> None:
@@ -72,3 +79,26 @@ def test_to_jsonable_sorts_unordered_collections_deterministically() -> None:
 
     assert serialized["tags"] == ["alpha", "beta"]
     assert serialized["nested"] == [["team", "ml"], ["team", "ops"]]
+
+
+@pytest.mark.parametrize("collection_type", [set, frozenset])
+def test_unordered_collection_limit_fails_before_normalization(collection_type: type) -> None:
+    payload = collection_type(range(MAX_COLLECTION_SIZE + 1))
+
+    def normalize_item(_item: object) -> object:
+        raise AssertionError("oversized unordered collection should fail before normalization")
+
+    with pytest.raises(ValueError, match="unordered collection exceeds maximum size"):
+        canonicalize_unordered_collection(
+            payload,
+            normalize_item=normalize_item,
+            limit=MAX_COLLECTION_SIZE,
+        )
+
+
+@pytest.mark.parametrize("collection_type", [set, frozenset])
+def test_to_jsonable_rejects_oversized_unordered_collections(collection_type: type) -> None:
+    payload = {"items": collection_type(range(MAX_COLLECTION_SIZE + 1))}
+
+    with pytest.raises(ValueError, match="unordered collection exceeds maximum size"):
+        to_jsonable(payload)


### PR DESCRIPTION
## Summary
- add an early size guard for unordered canonical collections when a limit is provided
- reject oversized set / frozenset values before normalization or sorting
- keep ordered list / tuple truncation deterministic through existing slicing behavior
- add regression tests for early failure and ordered collection limits

## Boundary
This is a follow-up to PR #29's deterministic unordered collection canonicalization.
It does not change public schema, README narrative, bundle / receipt semantics, EvidenceRecorder, or EvidenceStore.

## Compatibility
Oversized unordered collections now fail closed with a ValueError instead of being fully normalized and sorted before truncation. This avoids non-deterministic subset selection for set / frozenset while preserving hash determinism for supported payload sizes.

## Validation
- ruff check: passed
- ruff format --check: passed
- pytest: 75 passed, 1 skipped