### PR TITLE
Make evidence record appends atomic per store

### DIFF
--- a/agent_evidence/recorder.py
+++ b/agent_evidence/recorder.py
@@ -87,6 +87,36 @@ class EvidenceRecorder:
         metadata: Any | None = None,
         tags: list[str] | None = None,
     ) -> EvidenceEnvelope:
+        latest_hashes = getattr(self.store, "latest_hashes", None)
+        if callable(latest_hashes):
+            tip = latest_hashes()
+        else:
+            tip = (self.store.latest_event_hash(), self.store.latest_chain_hash())
+        return self._build_from_tip(
+            tip,
+            actor=actor,
+            event_type=event_type,
+            action=action,
+            inputs=inputs,
+            outputs=outputs,
+            context=context,
+            metadata=metadata,
+            tags=tags,
+        )
+
+    def _build_from_tip(
+        self,
+        latest_hashes: tuple[str | None, str | None],
+        *,
+        actor: str,
+        event_type: str | None = None,
+        action: str | None = None,
+        inputs: Any | None = None,
+        outputs: Any | None = None,
+        context: EvidenceContext | dict[str, Any] | None = None,
+        metadata: Any | None = None,
+        tags: list[str] | None = None,
+    ) -> EvidenceEnvelope:
         resolved_event_type = event_type or action
         if not resolved_event_type:
             raise ValueError("event_type is required.")
@@ -100,12 +130,7 @@ class EvidenceRecorder:
             metadata=ensure_json_object(metadata),
         )
         event_hash = compute_hash(event.model_dump(mode="json"))
-        latest_hashes = getattr(self.store, "latest_hashes", None)
-        if callable(latest_hashes):
-            previous_event_hash, previous_chain_hash = latest_hashes()
-        else:
-            previous_event_hash = self.store.latest_event_hash()
-            previous_chain_hash = self.store.latest_chain_hash()
+        previous_event_hash, previous_chain_hash = latest_hashes
         chain_hash = chain_digest_for_event(
             event_hash=event_hash,
             previous_chain_hash=previous_chain_hash,
@@ -120,6 +145,6 @@ class EvidenceRecorder:
         )
 
     def record(self, **kwargs: Any) -> EvidenceEnvelope:
-        envelope = self.build(**kwargs)
-        self.store.append(envelope)
-        return envelope
+        return self.store.append_atomic(
+            lambda latest_hashes: self._build_from_tip(latest_hashes, **kwargs)
+        )

--- a/agent_evidence/storage/base.py
+++ b/agent_evidence/storage/base.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import datetime
 
 from agent_evidence.models import EvidenceEnvelope
+
+LatestHashes = tuple[str | None, str | None]
+AtomicEnvelopeBuilder = Callable[[LatestHashes], EvidenceEnvelope]
 
 
 class EvidenceStore(ABC):
     @abstractmethod
     def append(self, envelope: EvidenceEnvelope) -> None:
         raise NotImplementedError
+
+    def append_atomic(self, build_envelope_from_tip: AtomicEnvelopeBuilder) -> EvidenceEnvelope:
+        latest_hashes = self.latest_hashes()
+        envelope = build_envelope_from_tip(latest_hashes)
+        self.append(envelope)
+        return envelope
 
     @abstractmethod
     def list(self) -> list[EvidenceEnvelope]:

--- a/agent_evidence/storage/local.py
+++ b/agent_evidence/storage/local.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from threading import RLock
 
 from agent_evidence.models import EvidenceEnvelope
-from agent_evidence.storage.base import EvidenceStore
+from agent_evidence.storage.base import EvidenceStore, LatestHashes
 
 
 class LocalEvidenceStore(EvidenceStore):
@@ -14,11 +16,25 @@ class LocalEvidenceStore(EvidenceStore):
     def __init__(self, path: str | Path):
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = RLock()
 
     def append(self, envelope: EvidenceEnvelope) -> None:
+        with self._lock:
+            self._append_unlocked(envelope)
+
+    def _append_unlocked(self, envelope: EvidenceEnvelope) -> None:
         with self.path.open("a", encoding="utf-8") as handle:
-            handle.write(envelope.model_dump_json())
-            handle.write("\n")
+            handle.write(envelope.model_dump_json() + "\n")
+
+    def append_atomic(
+        self,
+        build_envelope_from_tip: Callable[[LatestHashes], EvidenceEnvelope],
+    ) -> EvidenceEnvelope:
+        with self._lock:
+            latest_hashes = self._latest_hashes_unlocked()
+            envelope = build_envelope_from_tip(latest_hashes)
+            self._append_unlocked(envelope)
+            return envelope
 
     def _last_envelope(self) -> EvidenceEnvelope | None:
         if not self.path.exists() or self.path.stat().st_size == 0:
@@ -50,17 +66,18 @@ class LocalEvidenceStore(EvidenceStore):
         return EvidenceEnvelope.model_validate_json(bytes(reversed(line_bytes)).decode("utf-8"))
 
     def list(self) -> list[EvidenceEnvelope]:
-        if not self.path.exists():
-            return []
+        with self._lock:
+            if not self.path.exists():
+                return []
 
-        records: list[EvidenceEnvelope] = []
-        with self.path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                records.append(EvidenceEnvelope.model_validate_json(line))
-        return records
+            records: list[EvidenceEnvelope] = []
+            with self.path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    records.append(EvidenceEnvelope.model_validate_json(line))
+            return records
 
     def latest_event_hash(self) -> str | None:
         event_hash, _ = self.latest_hashes()
@@ -71,6 +88,10 @@ class LocalEvidenceStore(EvidenceStore):
         return chain_hash
 
     def latest_hashes(self) -> tuple[str | None, str | None]:
+        with self._lock:
+            return self._latest_hashes_unlocked()
+
+    def _latest_hashes_unlocked(self) -> tuple[str | None, str | None]:
         envelope = self._last_envelope()
         if envelope is None:
             return None, None

--- a/agent_evidence/storage/sql.py
+++ b/agent_evidence/storage/sql.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
+from threading import RLock
 from typing import Any
 
 from sqlalchemy import JSON, BigInteger, Index, Integer, String, create_engine, select
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 from agent_evidence.models import EvidenceEnvelope
-from agent_evidence.storage.base import EvidenceStore
+from agent_evidence.storage.base import EvidenceStore, LatestHashes
 
 
 def _to_epoch_micros(value: datetime) -> int:
@@ -56,6 +58,7 @@ class SqlEvidenceStore(EvidenceStore):
     def __init__(self, url: str):
         self.url = url
         self.engine = create_engine(url)
+        self._lock = RLock()
         Base.metadata.create_all(self.engine)
 
     def _from_row(self, row: EvidenceRecordRow) -> EvidenceEnvelope:
@@ -67,12 +70,12 @@ class SqlEvidenceStore(EvidenceStore):
             }
         )
 
-    def append(self, envelope: EvidenceEnvelope) -> None:
+    def _row_from_envelope(self, envelope: EvidenceEnvelope) -> EvidenceRecordRow:
         payload = envelope.model_dump(mode="json")
         event = payload["event"]
         context = event["context"]
         hashes = payload["hashes"]
-        row = EvidenceRecordRow(
+        return EvidenceRecordRow(
             schema_version=payload["schema_version"],
             event_id=event["event_id"],
             event_type=event["event_type"],
@@ -91,9 +94,32 @@ class SqlEvidenceStore(EvidenceStore):
             metadata_json=event["metadata"],
             hashes_json=hashes,
         )
-        with Session(self.engine) as session:
-            session.add(row)
-            session.commit()
+
+    def append(self, envelope: EvidenceEnvelope) -> None:
+        row = self._row_from_envelope(envelope)
+        with self._lock:
+            with Session(self.engine) as session, session.begin():
+                session.add(row)
+
+    def append_atomic(
+        self,
+        build_envelope_from_tip: Callable[[LatestHashes], EvidenceEnvelope],
+    ) -> EvidenceEnvelope:
+        with self._lock:
+            with Session(self.engine) as session, session.begin():
+                latest_hashes = self._latest_hashes_in_session(session)
+                envelope = build_envelope_from_tip(latest_hashes)
+                session.add(self._row_from_envelope(envelope))
+                return envelope
+
+    def _latest_hashes_in_session(self, session: Session) -> LatestHashes:
+        statement = select(EvidenceRecordRow.event_hash, EvidenceRecordRow.chain_hash).order_by(
+            EvidenceRecordRow.id.desc()
+        )
+        row = session.execute(statement.limit(1)).one_or_none()
+        if row is None:
+            return None, None
+        return row[0], row[1]
 
     def list(self) -> list[EvidenceEnvelope]:
         return self.query()
@@ -107,14 +133,9 @@ class SqlEvidenceStore(EvidenceStore):
         return chain_hash
 
     def latest_hashes(self) -> tuple[str | None, str | None]:
-        statement = select(EvidenceRecordRow.event_hash, EvidenceRecordRow.chain_hash).order_by(
-            EvidenceRecordRow.id.desc()
-        )
-        with Session(self.engine) as session:
-            row = session.execute(statement.limit(1)).one_or_none()
-        if row is None:
-            return None, None
-        return row[0], row[1]
+        with self._lock:
+            with Session(self.engine) as session:
+                return self._latest_hashes_in_session(session)
 
     def query(
         self,

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -1,8 +1,42 @@
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from agent_evidence.crypto.chain import verify_chain
 from agent_evidence.recorder import EvidenceRecorder
 from agent_evidence.storage.local import LocalEvidenceStore
+
+
+def _assert_single_linear_chain(records: list, expected_count: int) -> None:
+    assert len(records) == expected_count
+    assert verify_chain(records) == []
+
+    genesis_records = [record for record in records if record.hashes.previous_event_hash is None]
+    assert len(genesis_records) == 1
+
+    previous_hashes = [
+        record.hashes.previous_event_hash
+        for record in records
+        if record.hashes.previous_event_hash is not None
+    ]
+    assert len(previous_hashes) == len(set(previous_hashes))
+
+    records_by_event_hash = {record.hashes.event_hash: record for record in records}
+    assert len(records_by_event_hash) == expected_count
+
+    visited: set[str] = set()
+    cursor = records[-1]
+    while True:
+        event_hash = cursor.hashes.event_hash
+        assert event_hash not in visited
+        visited.add(event_hash)
+
+        previous_event_hash = cursor.hashes.previous_event_hash
+        if previous_event_hash is None:
+            break
+        assert previous_event_hash in records_by_event_hash
+        cursor = records_by_event_hash[previous_event_hash]
+
+    assert len(visited) == expected_count
 
 
 def test_local_store_appends_chain(tmp_path: Path) -> None:
@@ -85,3 +119,24 @@ def test_local_store_query_supports_span_hash_and_pagination(tmp_path: Path) -> 
 
     paged = store.query(offset=1, limit=1)
     assert [record.event.event_type for record in paged] == ["tool.call"]
+
+
+def test_local_store_record_is_atomic_for_multithreaded_appends(tmp_path: Path) -> None:
+    store = LocalEvidenceStore(tmp_path / "concurrent.evidence.jsonl")
+    recorder = EvidenceRecorder(store)
+    record_count = 32
+
+    def record_event(index: int) -> str:
+        envelope = recorder.record(
+            actor=f"worker-{index}",
+            event_type="concurrent.local",
+            inputs={"index": index},
+        )
+        return envelope.hashes.event_hash
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        event_hashes = list(executor.map(record_event, range(record_count)))
+
+    assert len(event_hashes) == record_count
+    assert len(set(event_hashes)) == record_count
+    _assert_single_linear_chain(store.list(), record_count)

--- a/tests/test_sql_store.py
+++ b/tests/test_sql_store.py
@@ -1,10 +1,12 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from agent_evidence.cli.main import main
+from agent_evidence.crypto.chain import verify_chain
 from agent_evidence.recorder import EvidenceRecorder
 from agent_evidence.storage.local import LocalEvidenceStore
 from agent_evidence.storage.sql import SqlEvidenceStore, _to_epoch_micros
@@ -12,6 +14,39 @@ from agent_evidence.storage.sql import SqlEvidenceStore, _to_epoch_micros
 
 def sqlite_url(path: Path) -> str:
     return f"sqlite+pysqlite:///{path}"
+
+
+def _assert_single_linear_chain(records: list, expected_count: int) -> None:
+    assert len(records) == expected_count
+    assert verify_chain(records) == []
+
+    genesis_records = [record for record in records if record.hashes.previous_event_hash is None]
+    assert len(genesis_records) == 1
+
+    previous_hashes = [
+        record.hashes.previous_event_hash
+        for record in records
+        if record.hashes.previous_event_hash is not None
+    ]
+    assert len(previous_hashes) == len(set(previous_hashes))
+
+    records_by_event_hash = {record.hashes.event_hash: record for record in records}
+    assert len(records_by_event_hash) == expected_count
+
+    visited: set[str] = set()
+    cursor = records[-1]
+    while True:
+        event_hash = cursor.hashes.event_hash
+        assert event_hash not in visited
+        visited.add(event_hash)
+
+        previous_event_hash = cursor.hashes.previous_event_hash
+        if previous_event_hash is None:
+            break
+        assert previous_event_hash in records_by_event_hash
+        cursor = records_by_event_hash[previous_event_hash]
+
+    assert len(visited) == expected_count
 
 
 def test_sql_store_appends_and_queries(tmp_path: Path) -> None:
@@ -210,3 +245,24 @@ def test_cli_migrate_and_query_sqlite(tmp_path: Path) -> None:
 def test_sql_store_epoch_micros_accepts_naive_datetime() -> None:
     naive_value = datetime(2026, 1, 1, 0, 0, 0, 123456)
     assert _to_epoch_micros(naive_value) == 1_767_225_600_123_456
+
+
+def test_sqlite_store_record_is_atomic_for_multithreaded_appends(tmp_path: Path) -> None:
+    store = SqlEvidenceStore(sqlite_url(tmp_path / "concurrent.db"))
+    recorder = EvidenceRecorder(store)
+    record_count = 32
+
+    def record_event(index: int) -> str:
+        envelope = recorder.record(
+            actor=f"worker-{index}",
+            event_type="concurrent.sqlite",
+            inputs={"index": index},
+        )
+        return envelope.hashes.event_hash
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        event_hashes = list(executor.map(record_event, range(record_count)))
+
+    assert len(event_hashes) == record_count
+    assert len(set(event_hashes)) == record_count
+    _assert_single_linear_chain(store.list(), record_count)


### PR DESCRIPTION
## Summary

This PR implements the second evidence integrity hardening step: atomic append for the default evidence recording path.

The default EvidenceRecorder.record() path now delegates to a store-level append_atomic(...) operation, so reading the latest chain tip, generating chain pointers, computing the chain hash, and persisting the envelope happen inside the store-level critical section.

## Changes

- Adds EvidenceStore.append_atomic(build_envelope_from_tip).
- Updates EvidenceRecorder.record() to use append_atomic(...) by default.
- Keeps EvidenceRecorder.build() for compatibility.
- Adds RLock-protected atomic append handling for LocalEvidenceStore.
- Writes JSONL envelopes as a single line write.
- Adds RLock + transaction-protected append handling for SqlEvidenceStore.
- Adds concurrent record() tests for LocalEvidenceStore and SQLite-backed SqlEvidenceStore.

## Validation

- ruff check: passed
- ruff format --check: passed
- pytest: 77 passed, 1 skipped, 15 warnings

## Verified behavior

The new tests verify that concurrent record() calls:

- produce the expected number of records
- produce exactly one genesis event
- do not produce duplicate previous_event_hash values among non-genesis events
- pass verify_chain()
- can be traced from latest head back to genesis

## Compatibility

- Public schema unchanged.
- Bundle and receipt field semantics unchanged.
- README narrative unchanged.
- Existing append(envelope) compatibility path is retained.

## Current guarantee boundary

This PR guarantees atomic append behavior for the tested single-process, shared-store-instance default record() path.

It does not claim cross-process JSONL safety, multi-instance database write safety, PostgreSQL advisory locking, database-level tip-row locking, or distributed append consistency. Those remain future hardening work.