### PR TITLE
Add pip-audit dependency vulnerability check

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,34 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,langchain,postgres]"
+          pip install pip-audit
+
+      - name: Run pip-audit
+        run: pip-audit


### PR DESCRIPTION
## Summary

Adds a minimal `pip-audit` CI check as the next supply-chain hardening step after the evidence integrity hardening cycle.

## Scope

This PR only adds dependency vulnerability auditing.

It does not:
- modify application code
- modify public schema
- restore any WIP stash
- touch AGT, Review Pack, poster, submission, or roadmap materials
- add SBOM generation
- add Dependabot
- add docs link checking

## Validation

- git diff --check: passed
- ruff check: passed
- ruff format --check: passed
- pytest: 77 passed, 1 skipped, 15 warnings
- GitHub `pip-audit` check: passed after PR #34 upgraded the `cryptography` dependency floor to `>=46.0.7`

## Current Status

PR #34 remediated the vulnerable `cryptography 45.0.7` resolution that this audit gate initially exposed. This PR has been rebased onto the updated `main`, and the new `pip-audit` check now passes without vulnerability ignore rules.

## Notes

This PR does not automatically upgrade vulnerable dependencies. Future vulnerability findings should be handled in separate dependency update PRs.

No vulnerability ignore entries are introduced in this PR.
