### PR TITLE
Upgrade cryptography dependency floor to 46.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
   "pytest>=8.0",
   "pre-commit>=3.7,<5.0",
   "ruff>=0.14,<1.0",
-  "cryptography>=44,<46",
+  "cryptography>=46.0.7,<47",
   "defusedxml>=0.7,<1.0",
   "langchain-core>=1.2,<2.0",
   "openai-agents>=0.12,<1.0",
@@ -40,7 +40,7 @@ sql = [
   "sqlalchemy>=2.0,<3.0",
 ]
 signing = [
-  "cryptography>=44,<46",
+  "cryptography>=46.0.7,<47",
 ]
 xml = [
   "defusedxml>=0.7,<1.0",


### PR DESCRIPTION
## Summary

Updates the direct `cryptography` optional dependency constraint to require `cryptography >=46.0.7,<47`.

This remediates the vulnerable `cryptography 45.0.7` resolution exposed by draft PR #33's new `pip-audit` gate.

## Scope

This PR only changes the `cryptography` dependency constraint in `pyproject.toml`.

It does not:
- modify application code
- modify public schema
- restore any WIP stash
- touch AGT, Review Pack, poster, submission, or roadmap materials
- add Dependabot
- add SBOM generation
- add docs link checking
- add vulnerability ignore rules

## Dependency Inventory

`cryptography` is a direct optional dependency in this repository:
- `dev` extra previously required `cryptography>=44,<46`
- `signing` extra previously required `cryptography>=44,<46`

The `<46` upper bound caused CI dependency resolution to install vulnerable `cryptography 45.0.7`. The new lower bound targets `46.0.7`, which is the first version that clears all three `cryptography` CVEs reported by the #33 audit job.

## Validation

- git diff --check: passed
- ruff check: passed
- ruff format --check: passed
- pytest: 77 passed, 1 skipped, 15 warnings
- local install resolved `cryptography 46.0.7`
- local long-lived `.venv` pip-audit no longer reports the three `cryptography 45.0.7` CVEs

## Notes

The long-lived local `.venv` still reports unrelated vulnerable packages from its existing environment. Those are intentionally left out of this PR. The clean #33 audit gate should be rerun after this dependency remediation lands.
