### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds a minimal Dependabot configuration for Python dependencies and GitHub Actions.

Scope:
- Adds .github/dependabot.yml
- Enables weekly checks for pip dependencies
- Enables weekly checks for GitHub Actions
- Does not modify application code
- Does not modify schema
- Does not restore any stash
- Does not touch AGT, Review Pack, poster, submission, roadmap, or paper materials
- Does not add SBOM generation
- Does not add docs link checking