### PR TITLE
Add SBOM generation workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,29 @@
+name: SBOM
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          artifact-name: agent-evidence-sbom.cdx.json
+          upload-artifact: true


### PR DESCRIPTION
## Summary

Adds a standalone SBOM generation workflow as the next supply-chain hardening step.

## Scope

This PR only adds `.github/workflows/sbom.yml`.

It does not:
- modify application code
- modify public schema
- modify the pip-audit workflow
- modify Dependabot configuration
- add vulnerability scanning
- restore any stash
- touch paper, AGT, Review Pack, poster, submission, or roadmap materials

## Behavior

The workflow generates a CycloneDX JSON SBOM using `anchore/sbom-action` and uploads it as a workflow artifact named `agent-evidence-sbom.cdx.json`.

## Validation

- git diff --check: passed
- existing CI checks: expected unchanged
- SBOM workflow: expected to generate an artifact
