### PR TITLE
Add documentation link check workflow

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,33 @@
+name: Docs Link Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-link-check:
+    name: Check documentation links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Exclude legacy workstation-absolute links until those historical docs
+          # are cleaned up, and exclude DOI URLs that reject CI requests with 403.
+          args: >-
+            --root-dir "${{ github.workspace }}"
+            --no-progress
+            --exclude '^file://.*/Users/zhangbin/GitHub/agent-evidence/'
+            --exclude '^https://doi\.org/10\.1145/(317087\.317089|1084805\.1084812|2076450\.2076466)$'
+            './**/*.md'
+          fail: true


### PR DESCRIPTION
## Summary

Adds a standalone documentation link check workflow as the next CI hardening step.

## Scope

This PR only adds `.github/workflows/docs-link-check.yml`.

It does not:
- modify application code
- modify public schema
- modify pip-audit
- modify Dependabot
- modify SBOM generation
- restore any stash
- touch paper, AGT, Review Pack, poster, submission, or roadmap materials

## Behavior

The workflow uses `lycheeverse/lychee-action` to check Markdown links.

It checks repository Markdown files and fails on broken links. The workflow includes two narrow exclusions for pre-existing documentation issues exposed by the first run:
- legacy workstation-absolute `/Users/zhangbin/GitHub/agent-evidence/...` links in historical docs
- three DOI URLs that return 403 to CI requests

These exclusions are intentionally narrow and should be revisited in a later documentation cleanup PR.

## Validation

- git diff --check: passed
- existing CI checks: expected unchanged
- docs link check: expected to run on pull requests and main pushes
