### PR TITLE
Clean up documentation link check exclusions

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -22,12 +22,10 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          # Exclude legacy workstation-absolute links until those historical docs
-          # are cleaned up, and exclude DOI URLs that reject CI requests with 403.
+          # These DOI resolver URLs return 403 in CI even though the DOI text is valid.
           args: >-
             --root-dir "${{ github.workspace }}"
             --no-progress
-            --exclude '^file://.*/Users/zhangbin/GitHub/agent-evidence/'
             --exclude '^https://doi\.org/10\.1145/(317087\.317089|1084805\.1084812|2076450\.2076466)$'
             './**/*.md'
           fail: true

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,7 +249,7 @@ agent-evidence export automaton \
 
 ## 受控释放表面
 
-位于 [v0.1-live-chain](/Users/zhangbin/GitHub/agent-evidence/release/v0.1-live-chain/README.md) 的受控样品发布属于历史 lineage surface，并不是当前主入口。
+位于 [v0.1-live-chain](release/v0.1-live-chain/README.md) 的受控样品发布属于历史 lineage surface，并不是当前主入口。
 
 该历史样品轨道在 Zenodo 上保留原始 DOI：
 https://doi.org/10.5281/zenodo.19055948
@@ -266,7 +266,7 @@ https://doi.org/10.5281/zenodo.19055948
 
 它与当前 Agent Evidence / AEP v0.1 package 路径的关系，统一见 [docs/lineage.md](docs/lineage.md)。
 
-正式的样本发布说明是[RELEASE_NOTE.md](/Users/zhangbin/GitHub/agent-evidence/release/v0.1-live-chain/RELEASE_NOTE.md)。
+正式的样本发布说明是[RELEASE_NOTE.md](release/v0.1-live-chain/RELEASE_NOTE.md)。
 
 ## CLI 示例
 

--- a/release/v0.1-live-chain/README.md
+++ b/release/v0.1-live-chain/README.md
@@ -9,20 +9,20 @@ Positioning:
 
 Canonical artifacts:
 
-- Release note: [RELEASE_NOTE.md](/Users/zhangbin/GitHub/agent-evidence/release/v0.1-live-chain/RELEASE_NOTE.md)
-- Schema: [schema_v0.1.json](/Users/zhangbin/GitHub/agent-evidence/agent_evidence/aep/schema_v0.1.json)
-- Verify CLI: [main.py](/Users/zhangbin/GitHub/agent-evidence/agent_evidence/cli/main.py)
-- LangChain exporter: [export_evidence.py](/Users/zhangbin/GitHub/agent-evidence/integrations/langchain/export_evidence.py)
-- Automaton exporter: [automaton.py](/Users/zhangbin/GitHub/agent-evidence/agent_evidence/integrations/automaton.py)
-- Live runbook: [LIVE_RUNBOOK.md](/Users/zhangbin/GitHub/agent-evidence/integrations/automaton/LIVE_RUNBOOK.md)
-- Boundary statement: [What-AEP-proves-and-what-it-does-not-prove.md](/Users/zhangbin/GitHub/agent-evidence/release/v0.1-live-chain/What-AEP-proves-and-what-it-does-not-prove.md)
+- Release note: [RELEASE_NOTE.md](RELEASE_NOTE.md)
+- Schema: [schema_v0.1.json](../../agent_evidence/aep/schema_v0.1.json)
+- Verify CLI: [main.py](../../agent_evidence/cli/main.py)
+- LangChain exporter: [export_evidence.py](../../integrations/langchain/export_evidence.py)
+- Automaton exporter: [automaton.py](../../agent_evidence/integrations/automaton.py)
+- Live runbook: [LIVE_RUNBOOK.md](../../integrations/automaton/LIVE_RUNBOOK.md)
+- Boundary statement: [What-AEP-proves-and-what-it-does-not-prove.md](What-AEP-proves-and-what-it-does-not-prove.md)
 
 Public fixtures:
 
-- Live bundle without runtime root: [manifest.json](/Users/zhangbin/GitHub/agent-evidence/tests/fixtures/agent_evidence_profile/valid/live-automaton-bundle/manifest.json)
-- Live bundle with runtime root: [manifest.json](/Users/zhangbin/GitHub/agent-evidence/tests/fixtures/agent_evidence_profile/valid/live-automaton-runtime-root-bundle/manifest.json)
-- Tampered live bundle without runtime root: [manifest.json](/Users/zhangbin/GitHub/agent-evidence/tests/fixtures/agent_evidence_profile/invalid/live-automaton-tampered-bundle/manifest.json)
-- Tampered live bundle with runtime root: [manifest.json](/Users/zhangbin/GitHub/agent-evidence/tests/fixtures/agent_evidence_profile/invalid/live-automaton-runtime-root-tampered-bundle/manifest.json)
+- Live bundle without runtime root: [manifest.json](../../tests/fixtures/agent_evidence_profile/valid/live-automaton-bundle/manifest.json)
+- Live bundle with runtime root: [manifest.json](../../tests/fixtures/agent_evidence_profile/valid/live-automaton-runtime-root-bundle/manifest.json)
+- Tampered live bundle without runtime root: [manifest.json](../../tests/fixtures/agent_evidence_profile/invalid/live-automaton-tampered-bundle/manifest.json)
+- Tampered live bundle with runtime root: [manifest.json](../../tests/fixtures/agent_evidence_profile/invalid/live-automaton-runtime-root-tampered-bundle/manifest.json)
 
 Minimal verification surface:
 

--- a/release/v0.1-live-chain/RELEASE_NOTE.md
+++ b/release/v0.1-live-chain/RELEASE_NOTE.md
@@ -25,7 +25,7 @@ This release packages the first public, reproducible live-chain specimen of AEP 
 - no external signing / anchoring by default
 - strength depends on capture boundary and anchoring model
 
-See the boundary statement: [What-AEP-proves-and-what-it-does-not-prove.md](/Users/zhangbin/GitHub/agent-evidence/release/v0.1-live-chain/What-AEP-proves-and-what-it-does-not-prove.md)
+See the boundary statement: [What-AEP-proves-and-what-it-does-not-prove.md](What-AEP-proves-and-what-it-does-not-prove.md)
 
 ## What this release contains
 


### PR DESCRIPTION
## Summary

Cleans up the narrow link-check exclusions introduced when the Markdown link check workflow was added.

## Scope

This PR only addresses documentation link-check cleanup.

It does not:
- modify application code
- modify public schema
- modify CLI or validator code
- modify pip-audit, Dependabot, or SBOM workflows
- restore any stash
- touch paper, AGT, Review Pack, poster, submission, or roadmap materials

## Changes

- Replaces historical local absolute paths with repository-relative Markdown links.
- Removes the legacy workstation path exclusion from the docs link check workflow.
- Keeps only the narrow DOI exclusion for three DOI resolver URLs that return 403 in CI.

## Validation

- git diff --check: passed
- docs link check: expected to pass in GitHub Actions
- existing CI checks: expected unchanged
