### PR TITLE
Improve validator error aggregation and fail-fast behavior

### DIFF
--- a/agent_evidence/oap.py
+++ b/agent_evidence/oap.py
@@ -72,6 +72,44 @@ def _issue(stage: str, code: str, path: str, message: str) -> dict[str, str]:
     }
 
 
+def _stage(
+    name: str,
+    issues: list[dict[str, str]],
+    *,
+    skipped: bool = False,
+    skip_reason: str | None = None,
+) -> dict[str, Any]:
+    stage: dict[str, Any] = {
+        "name": name,
+        "ok": not issues and not skipped,
+        "issues": issues,
+        "skipped": skipped,
+    }
+    if skip_reason is not None:
+        stage["skip_reason"] = skip_reason
+    return stage
+
+
+def _flatten_issues(stages: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [issue for stage in stages for issue in stage["issues"]]
+
+
+def _issue_summary(issues: list[dict[str, str]]) -> dict[str, dict[str, int]]:
+    by_stage: dict[str, int] = {}
+    by_code: dict[str, int] = {}
+    for issue in issues:
+        by_stage[issue["stage"]] = by_stage.get(issue["stage"], 0) + 1
+        by_code[issue["code"]] = by_code.get(issue["code"], 0) + 1
+    return {
+        "by_stage": dict(sorted(by_stage.items())),
+        "by_code": dict(sorted(by_code.items())),
+    }
+
+
+def _skipped_stage(name: str, reason: str) -> dict[str, Any]:
+    return _stage(name, [], skipped=True, skip_reason=reason)
+
+
 def _validate_schema(
     profile: dict[str, Any], schema_path: str | Path = SCHEMA_PATH
 ) -> list[dict[str, str]]:
@@ -382,32 +420,59 @@ def build_validation_report(
     *,
     schema_path: str | Path | None = None,
     source: str | None = None,
+    fail_fast: bool = True,
 ) -> dict[str, Any]:
     resolved_schema_path = schema_path or SCHEMA_PATH
+    stages: list[dict[str, Any]] = []
     schema_issues = _validate_schema(profile, resolved_schema_path)
-    reference_issues: list[dict[str, str]] = []
-    consistency_issues: list[dict[str, str]] = []
-    integrity_issues: list[dict[str, str]] = []
+    stages.append(_stage("schema", schema_issues))
 
-    if not schema_issues:
+    if schema_issues:
+        skip_reason = "Skipped because schema validation failed."
+        stages.extend(
+            [
+                _skipped_stage("references", skip_reason),
+                _skipped_stage("consistency", skip_reason),
+                _skipped_stage("integrity", skip_reason),
+            ]
+        )
+    else:
         reference_issues = _validate_reference_closure(profile)
-    if not schema_issues and not reference_issues:
-        consistency_issues = _validate_link_consistency(profile)
-    if not schema_issues and not reference_issues and not consistency_issues:
-        integrity_issues = _validate_integrity(profile)
+        stages.append(_stage("references", reference_issues))
 
-    stages = [
-        {"name": "schema", "ok": not schema_issues, "issues": schema_issues},
-        {"name": "references", "ok": not reference_issues, "issues": reference_issues},
-        {"name": "consistency", "ok": not consistency_issues, "issues": consistency_issues},
-        {"name": "integrity", "ok": not integrity_issues, "issues": integrity_issues},
-    ]
-    issues = [issue for stage in stages for issue in stage["issues"]]
+        if fail_fast and reference_issues:
+            skip_reason = "Skipped because fail_fast stopped after reference validation failed."
+            stages.extend(
+                [
+                    _skipped_stage("consistency", skip_reason),
+                    _skipped_stage("integrity", skip_reason),
+                ]
+            )
+        else:
+            consistency_issues = _validate_link_consistency(profile)
+            stages.append(_stage("consistency", consistency_issues))
+
+            if fail_fast and consistency_issues:
+                stages.append(
+                    _skipped_stage(
+                        "integrity",
+                        "Skipped because fail_fast stopped after consistency validation failed.",
+                    )
+                )
+            else:
+                stages.append(_stage("integrity", _validate_integrity(profile)))
+
+    issues = _flatten_issues(stages)
+    issue_summary = _issue_summary(issues)
     report = {
         "ok": not issues,
         "profile": f"{PROFILE_NAME}@{PROFILE_VERSION}",
         "source": source,
+        "fail_fast": fail_fast,
         "issue_count": len(issues),
+        "primary_error_code": issues[0]["code"] if issues else None,
+        "issues": issues,
+        "issue_summary": issue_summary,
         "stages": stages,
         "summary": render_summary_lines(
             {
@@ -416,6 +481,7 @@ def build_validation_report(
                 "source": source,
                 "issue_count": len(issues),
                 "issues": issues,
+                "issue_summary": issue_summary,
             }
         ),
     }
@@ -426,9 +492,15 @@ def validate_profile_file(
     path: str | Path,
     *,
     schema_path: str | Path | None = None,
+    fail_fast: bool = True,
 ) -> dict[str, Any]:
     profile = load_profile(path)
-    return build_validation_report(profile, schema_path=schema_path, source=str(path))
+    return build_validation_report(
+        profile,
+        schema_path=schema_path,
+        source=str(path),
+        fail_fast=fail_fast,
+    )
 
 
 def render_summary_lines(report: dict[str, Any]) -> list[str]:
@@ -437,7 +509,17 @@ def render_summary_lines(report: dict[str, Any]) -> list[str]:
     if report["ok"]:
         return [f"PASS {profile} {source}"]
 
+    issues = report.get("issues")
+    if issues is None:
+        issues = _flatten_issues(report.get("stages", []))
+
     lines = [f"FAIL {profile} {source} ({report['issue_count']} issue(s))"]
-    for issue in report["issues"]:
+    issue_summary = report.get("issue_summary")
+    if issue_summary and issue_summary.get("by_stage"):
+        stage_counts = ", ".join(
+            f"{stage}={count}" for stage, count in issue_summary["by_stage"].items()
+        )
+        lines.append(f"Stages with issues: {stage_counts}")
+    for issue in issues:
         lines.append(f"[{issue['code']}] {issue['path']}: {issue['message']}")
     return lines

--- a/tests/test_operation_accountability_profile.py
+++ b/tests/test_operation_accountability_profile.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from pathlib import Path
 
@@ -5,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from agent_evidence.cli.main import main
-from agent_evidence.oap import validate_profile_file
+from agent_evidence.oap import build_validation_report, load_profile, validate_profile_file
 
 EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
 
@@ -52,8 +53,82 @@ def test_invalid_operation_accountability_profiles_fail(
 
     assert report["ok"] is False
     assert report["issue_count"] == expected_issue_count
+    assert report["primary_error_code"] == expected_code
+    assert report["issues"]
+    assert report["issue_summary"]["by_code"][expected_code] >= 1
     issue_codes = {issue["code"] for stage in report["stages"] for issue in stage["issues"]}
     assert expected_code in issue_codes
+
+
+def test_validation_report_exposes_flattened_issues_and_summary_counts() -> None:
+    report = validate_profile_file(EXAMPLES / "invalid-unclosed-reference.json")
+
+    assert report["ok"] is False
+    assert report["fail_fast"] is True
+    assert report["issues"] == [issue for stage in report["stages"] for issue in stage["issues"]]
+    assert report["primary_error_code"] == "unresolved_output_ref"
+    assert report["issue_summary"] == {
+        "by_stage": {"references": 1},
+        "by_code": {"unresolved_output_ref": 1},
+    }
+    assert "Stages with issues: references=1" in report["summary"]
+
+
+def test_validation_fail_fast_stops_after_first_failed_semantic_stage() -> None:
+    profile = load_profile(EXAMPLES / "minimal-valid-evidence.json")
+    profile["operation"]["output_refs"] = ["missing-output"]
+    profile["evidence"]["integrity"]["statement_digest"] = "sha256:" + "0" * 64
+
+    report = build_validation_report(profile, fail_fast=True)
+
+    assert report["issue_count"] == 1
+    assert report["primary_error_code"] == "unresolved_output_ref"
+    skipped = {stage["name"]: stage["skipped"] for stage in report["stages"]}
+    assert skipped == {
+        "schema": False,
+        "references": False,
+        "consistency": True,
+        "integrity": True,
+    }
+
+
+def test_validation_can_aggregate_structurally_safe_later_stage_errors() -> None:
+    profile = load_profile(EXAMPLES / "minimal-valid-evidence.json")
+    profile["operation"]["output_refs"] = ["missing-output"]
+    profile["evidence"]["integrity"]["statement_digest"] = "sha256:" + "0" * 64
+
+    report = build_validation_report(profile, fail_fast=False)
+
+    assert report["fail_fast"] is False
+    issue_codes = {issue["code"] for issue in report["issues"]}
+    assert {
+        "unresolved_output_ref",
+        "provenance_output_refs_mismatch",
+        "statement_digest_mismatch",
+    } <= issue_codes
+    assert report["issue_summary"]["by_stage"] == {
+        "consistency": 1,
+        "integrity": 1,
+        "references": 1,
+    }
+    assert not any(stage["skipped"] for stage in report["stages"])
+
+
+def test_schema_failure_skips_dependent_stages_even_when_aggregating() -> None:
+    profile = copy.deepcopy(load_profile(EXAMPLES / "minimal-valid-evidence.json"))
+    del profile["actor"]
+
+    report = build_validation_report(profile, fail_fast=False)
+
+    assert report["primary_error_code"] == "schema_violation"
+    assert report["issue_summary"]["by_stage"] == {"schema": 1}
+    skipped = {stage["name"]: stage["skipped"] for stage in report["stages"]}
+    assert skipped == {
+        "schema": False,
+        "references": True,
+        "consistency": True,
+        "integrity": True,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR improves validator error reporting while keeping the existing default validation path compatible.

## Summary
- Adds explicit `fail_fast` control to `build_validation_report(...)` and `validate_profile_file(...)`.
- Keeps default validation behavior fail-fast by stage to preserve existing fixture and CLI expectations.
- Adds top-level flattened `issues`, `primary_error_code`, and `issue_summary` fields to validation reports.
- Marks skipped stages explicitly with `skipped` and `skip_reason`.
- Supports `fail_fast=False` to aggregate structurally safe later-stage errors after schema validation passes.

## Scope
This PR only modifies the operation accountability profile validator and its tests.

It does not:
- modify public schema
- modify application runtime behavior
- modify CLI command wiring
- restore any stash
- touch paper, AGT, Review Pack, poster, submission, or roadmap materials

## Validation
- git diff --check: passed
- ruff check: passed
- ruff format --check: passed
- pytest: 81 passed, 1 skipped, 15 warnings
