### PR TITLE
Add AI agent entry points for evidence packaging layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,29 @@ The current boundary is deliberately narrow: runtime evidence export,
 operation-accountability profile validation, offline bundles, verification
 receipts, and local review packs for AI agent runs.
 
+## Repository role
+
+This repository is the evidence packaging and verification layer for the Execution Evidence Bridge.
+
+It packages runtime evidence into portable artifacts and supports offline verification, receipts, signed exports, and review packs.
+
+## Execution Evidence Bridge Agent Instructions
+
+- Treat this repository as the evidence packaging and verification layer, not the execution-integrity kernel.
+- Use `fdo-kernel-mvk` for deterministic execution proof, replay verification, checksum/checkpoint integrity, and tamper detection.
+- Use `agent-evidence verify-bundle --bundle-dir ../fdo-kernel-mvk/mvk-aep-bundle` to verify the MVK bridge bundle when the sibling repository exists.
+- Use the existing CLI commands for profile validation, export verification, signed exports, and review packs.
+- Use `digital-biosphere-architecture` as the canonical architecture and AI discovery hub.
+- Do not claim legal non-repudiation, compliance certification, AI Act approval, official FDO standard adoption, or production forensic timestamping.
+
+## Execution Evidence Bridge Useful Checks
+
+```bash
+grep -R "Execution Evidence Bridge" README.md README.zh-CN.md docs llms.txt AGENTS.md
+grep -R "not legal non-repudiation" llms.txt AGENTS.md docs
+./.venv/bin/pytest -q tests/test_cli.py tests/test_aep_profile.py
+```
+
 ## When Agents Should Use It
 
 Use this repository when the user needs to:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use agent-evidence in derived work, cite it using this metadata."
 type: software
 title: "agent-evidence"
-abstract: "Runtime evidence exporter and validator for AI agent and service operations."
+abstract: "Evidence packaging and verification layer for the Execution Evidence Bridge. It supports portable evidence bundles, offline verification, receipts, signed exports, and reviewer-facing review packs for AI agent and service operations."
 authors:
   - family-names: "Zhang"
     given-names: "Bin"
@@ -18,3 +18,8 @@ keywords:
   - "operation accountability"
   - "validation"
   - "evidence bundles"
+  - "Execution Evidence Bridge"
+  - "offline verification"
+  - "signed export"
+  - "review pack"
+  - "verifiable AI"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ DOI: [10.5281/zenodo.19334061](https://doi.org/10.5281/zenodo.19334061)
   `agent-evidence==0.6.0` on PyPI and archived on Zenodo; not legal,
   compliance, or AI Act approval
 
+## AI / agent entry points
+
+- `llms.txt`
+- `AGENTS.md`
+- `CITATION.cff`
+- Canonical AI discovery index: [https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-discovery-index.md](https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-discovery-index.md)
+- Canonical AI citation map: [https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-citation-map.json](https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-citation-map.json)
+
+These files help AI systems and agents discover, cite, and verify this
+repository role faster. The canonical cross-repository discovery surface stays
+in `digital-biosphere-architecture`.
+
 ## Quick Start
 
 Install from source:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,6 +126,16 @@ agent governance 平台。
 MVK bridge path：
 `fdo-kernel-mvk audit_bundle.json -> AEP-compatible bundle -> agent-evidence verify-bundle / signed export / review pack workflows`。
 
+## AI / agent 入口
+
+- `llms.txt`
+- `AGENTS.md`
+- `CITATION.cff`
+- 主索引：digital-biosphere-architecture 的 `docs/ai-discovery-index.md`
+- 引用地图：digital-biosphere-architecture 的 `docs/ai-citation-map.json`
+
+这些文件用于帮助 AI / agent 更快发现、引用和复核本仓库角色，不是新的宣传材料。权威跨仓库索引仍然放在 `digital-biosphere-architecture`。
+
 ## 下一步重点
 
 - external-context evidence

--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,11 @@
 # agent-evidence
 
+中文：
+`agent-evidence` 是 Execution Evidence Bridge 的证据打包和验证层。它负责把 AI / Agent 运行事件整理成可交付证据，并支持 offline verification、receipt、signed export 和 review pack。
+
+English:
+`agent-evidence` is the evidence packaging and verification layer in the Execution Evidence Bridge. It packages runtime evidence into portable artifacts and supports offline verification, receipts, signed exports, and review packs.
+
 `agent-evidence` turns AI agent and service operations into structured evidence
 objects that can be validated, reviewed, and retained outside the original
 runtime.
@@ -26,6 +32,37 @@ Citation path: `CITATION.cff` and `docs/how-to-cite.md`.
 Attribution path: `ATTRIBUTION.md`.
 
 Recommendation policy path: `RECOMMENDATION_POLICY.md`.
+
+## Canonical architecture / AI discovery
+
+- Architecture hub: https://github.com/joy7758/digital-biosphere-architecture
+- AI discovery index: https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-discovery-index.md
+- AI citation map: https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-citation-map.json
+- Bridge map: https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/execution-evidence-bridge-map.md
+
+## Local verification commands
+
+```bash
+agent-evidence verify-bundle --bundle-dir ../fdo-kernel-mvk/mvk-aep-bundle
+```
+
+Also keep using existing documented commands such as `validate-profile`,
+`export`, `verify-export`, `verify-bundle`, and review-pack commands.
+
+## Boundary
+
+- This repository packages and verifies evidence artifacts.
+- This repository does not prove deterministic execution by itself.
+- Use fdo-kernel-mvk for execution-integrity proof.
+- Use verifiable-agent-demo for the shortest guided walkthrough.
+
+## Non-claims
+
+- not legal non-repudiation
+- not compliance certification
+- not AI Act approval
+- not official FDO standard adoption
+- not production forensic timestamping
 
 Current callable surface: local CLI command `agent-evidence`.
 


### PR DESCRIPTION
## Summary

This PR adds lightweight AI / agent entry points for `agent-evidence`.

The goal is not to duplicate the architecture hub. The goal is to help AI systems and agents quickly identify this repository as the evidence packaging and verification layer in the Execution Evidence Bridge.

## Added or updated entry points

- `llms.txt`
- `AGENTS.md`
- `CITATION.cff`
- `README.md`
- `README.zh-CN.md`

## Repository role

`agent-evidence` packages and verifies portable evidence artifacts:

- evidence bundles
- offline verification
- receipts
- signed exports
- review packs

## Boundary

`agent-evidence` is not the execution-integrity kernel. Use `fdo-kernel-mvk` for deterministic execution proof, replay verification, checksum/checkpoint integrity, and tamper detection.

## Canonical hub

The canonical cross-repository AI discovery surface remains in:

- https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-discovery-index.md
- https://github.com/joy7758/digital-biosphere-architecture/blob/main/docs/ai-citation-map.json

## Test results

```bash
grep -R "Execution Evidence Bridge" README.md README.zh-CN.md docs llms.txt AGENTS.md | head -30
grep -R "not legal non-repudiation" llms.txt AGENTS.md docs | head -20
./.venv/bin/pytest -q tests/test_cli.py tests/test_aep_profile.py
```

Result:

```text
15 passed
```

## Non-claims

This does not claim legal non-repudiation, compliance certification, AI Act approval, official FDO standard adoption, or production forensic timestamping.
